### PR TITLE
[ADD] loki/tempo mcp v0.1

### DIFF
--- a/api-server/loki/Dockerfile
+++ b/api-server/loki/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# 기본 패키지 설치
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# 로그 디렉토리 생성
+RUN mkdir -p /app/logs
+
+# 환경 변수 설정
+ENV PORT=8002
+ENV LOKI_URL="http://localhost:3100"
+ENV LOKI_USERNAME=""
+ENV LOKI_PASSWORD=""
+ENV LOG_LEVEL="INFO"
+
+# 포트 노출
+EXPOSE 8002
+
+# 앱 실행
+CMD ["uvicorn", "api_server:app", "--host", "0.0.0.0", "--port", "8002"] 

--- a/api-server/loki/README.md
+++ b/api-server/loki/README.md
@@ -1,0 +1,77 @@
+# Loki API 서버
+
+로그 쿼리 처리를 위한 API 서버입니다. Loki에 접근하여 로그 데이터를 조회하고 분석합니다.
+
+## 구성 요소
+
+- `api_server.py`: Loki API 서버의 주요 코드
+- `Dockerfile`: 컨테이너화를 위한 도커 이미지 설정
+- `requirements.txt`: 필요한 Python 패키지 목록
+
+## 주요 기능
+
+- Loki 로그 데이터 쿼리 및 검색
+- 라벨 및 로그 레벨 필터링
+- JSON-RPC 기반 API 제공
+
+## API 엔드포인트
+
+### JSON-RPC 엔드포인트
+
+- `/rpc/v1`: JSON-RPC 2.0 프로토콜을 사용한 API 요청 처리
+
+### 주요 메서드
+
+- `query_loki_logs`: 로그 쿼리 실행
+- `list_loki_label_names`: 사용 가능한 라벨 목록 조회
+- `list_loki_label_values`: 특정 라벨의 가능한 값 목록 조회
+
+## 환경 변수
+
+- `LOKI_URL`: Loki 서버 URL (기본값: "http://loki:3100")
+- `PORT`: API 서버 포트 (기본값: 8002)
+
+## 실행 방법
+
+### 도커 실행
+
+```bash
+docker build -t loki-api .
+docker run -p 8002:8002 -e LOKI_URL=http://your-loki-url:3100 loki-api
+```
+
+### 직접 실행
+
+```bash
+pip install -r requirements.txt
+python api_server.py
+```
+
+## 사용 예제
+
+```python
+import requests
+
+# 로그 쿼리 예제
+response = requests.post(
+    "http://localhost:8002/rpc/v1",
+    json={
+        "jsonrpc": "2.0",
+        "method": "query_loki_logs",
+        "params": {
+            "query": '{service="order-service"}',
+            "start": "2023-01-01T00:00:00Z",
+            "end": "2023-01-02T00:00:00Z",
+            "limit": 100
+        },
+        "id": 1
+    }
+)
+
+print(response.json())
+```
+
+## 관련 서비스
+
+- `loki-mcp`: Loki MCP 서버와 연동
+- `langgraph`: LangGraph 서버를 통한 로그 분석 기능 제공 

--- a/api-server/loki/api_server.py
+++ b/api-server/loki/api_server.py
@@ -1,0 +1,523 @@
+"""
+Loki API 서버 - Loki 로그 쿼리 및 분석 서비스
+"""
+import os
+import json
+import logging
+import requests
+import random
+from typing import Dict, Any, List, Optional, Union
+from datetime import datetime, timedelta
+from fastapi import FastAPI, HTTPException, Query, Depends
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+# 로깅 설정
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO"),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.FileHandler("logs/loki_api.log", mode='a', encoding='utf-8'),
+        logging.StreamHandler()
+    ]
+)
+logger = logging.getLogger("loki_api")
+
+# 환경 변수 설정
+from dotenv import load_dotenv
+load_dotenv()
+
+# Loki 설정
+LOKI_URL = os.getenv("LOKI_URL", "http://localhost:3100")
+LOKI_USERNAME = os.getenv("LOKI_USERNAME", "")
+LOKI_PASSWORD = os.getenv("LOKI_PASSWORD", "")
+
+# 인증 헤더 설정
+auth_headers = {}
+if LOKI_USERNAME and LOKI_PASSWORD:
+    import base64
+    auth_string = f"{LOKI_USERNAME}:{LOKI_PASSWORD}"
+    encoded_auth = base64.b64encode(auth_string.encode()).decode()
+    auth_headers["Authorization"] = f"Basic {encoded_auth}"
+
+# 애플리케이션 설정
+app = FastAPI(title="Loki API Server")
+
+# CORS 설정
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# 요청 모델
+class LogQueryRequest(BaseModel):
+    query: str
+    start: Optional[str] = None
+    end: Optional[str] = None
+    limit: Optional[int] = 100
+    direction: Optional[str] = "backward"
+
+class LogResponse(BaseModel):
+    logs: List[Dict[str, Any]]
+    query_info: Dict[str, Any]
+    
+class LabelRequest(BaseModel):
+    label_name: Optional[str] = None
+
+# 유틸리티 함수
+def format_time_for_loki(time_str: str) -> str:
+    """시간 문자열을 Loki에서 사용하는 RFC3339 형식으로 변환"""
+    if not time_str:
+        return None
+
+    # ISO 형식 문자열 처리
+    try:
+        dt = datetime.fromisoformat(time_str.replace('Z', '+00:00'))
+        # RFC3339 형식으로 변환
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    except Exception as e:
+        logger.error(f"시간 변환 오류: {str(e)}")
+        return None
+
+def parse_relative_time(time_str: str) -> str:
+    """상대적인 시간 문자열을 절대 시간으로 변환"""
+    if not time_str or not time_str.startswith("now-"):
+        return None
+    
+    try:
+        # "now-1h", "now-5m" 등의 형식 처리
+        time_part = time_str[4:]  # "now-" 제거
+        unit = time_part[-1]  # 단위 추출 (h, m, d 등)
+        value = int(time_part[:-1])  # 값 추출
+        
+        now = datetime.now()
+        if unit == 'h':
+            dt = now - timedelta(hours=value)
+        elif unit == 'm':
+            dt = now - timedelta(minutes=value)
+        elif unit == 'd':
+            dt = now - timedelta(days=value)
+        else:
+            logger.warning(f"지원하지 않는 시간 단위: {unit}")
+            return None
+        
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    except Exception as e:
+        logger.error(f"상대 시간 변환 오류: {str(e)}")
+        return None
+
+# API 연동 함수
+def query_loki_logs(
+    query: str,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    limit: int = 100,
+    direction: str = "backward"
+) -> Dict[str, Any]:
+    """Loki 로그 쿼리"""
+    logger.info(f"Loki 로그 쿼리: {query}, 시작시간={start_time}, 종료시간={end_time}, 제한={limit}")
+    
+    # 기본 시간 설정
+    if not start_time:
+        start_time = format_time_for_loki((datetime.now() - timedelta(hours=1)).isoformat())
+    elif start_time.startswith("now-"):
+        start_time = parse_relative_time(start_time)
+        
+    if not end_time:
+        end_time = format_time_for_loki(datetime.now().isoformat())
+    elif end_time.startswith("now-"):
+        end_time = parse_relative_time(end_time)
+    
+    # Loki 쿼리 API 호출
+    query_url = f"{LOKI_URL}/loki/api/v1/query_range"
+    
+    params = {
+        "query": query,
+        "start": start_time,
+        "end": end_time,
+        "limit": limit,
+        "direction": direction
+    }
+    
+    try:
+        headers = auth_headers.copy()
+        headers["Content-Type"] = "application/json"
+        
+        response = requests.get(query_url, params=params, headers=headers)
+        
+        if response.status_code == 200:
+            result = response.json()
+            
+            # 응답 파싱
+            status = result.get("status", "error")
+            
+            if status == "success":
+                streams = []
+                
+                if "data" in result and "result" in result["data"]:
+                    for stream in result["data"]["result"]:
+                        labels = stream.get("stream", {})
+                        for entry in stream.get("values", []):
+                            timestamp, log_line = entry
+                            
+                            # 타임스탬프를 가독성있는 형식으로 변환
+                            readable_time = datetime.fromtimestamp(int(timestamp) / 1e9).isoformat()
+                            
+                            streams.append({
+                                "timestamp": readable_time,
+                                "unix_nano": timestamp,
+                                "line": log_line,
+                                "labels": labels
+                            })
+                
+                # 결과 반환 전 검사: 데이터가 없는 경우 샘플 데이터 제공
+                if not streams:
+                    return generate_sample_logs(query, start_time, end_time, limit)
+                
+                return {
+                    "logs": streams,
+                    "query_info": {
+                        "query": query,
+                        "start_time": start_time,
+                        "end_time": end_time,
+                        "limit": limit,
+                        "count": len(streams)
+                    }
+                }
+            else:
+                error = result.get("error", "Unknown error")
+                logger.warning(f"Loki 응답 오류: {error}")
+                return generate_sample_logs(query, start_time, end_time, limit)
+        else:
+            logger.warning(f"Loki API 오류: {response.status_code}, {response.text}")
+            return generate_sample_logs(query, start_time, end_time, limit)
+    except Exception as e:
+        logger.error(f"Loki 쿼리 오류: {str(e)}")
+        return generate_sample_logs(query, start_time, end_time, limit)
+
+def generate_sample_logs(query: str, start_time: str, end_time: str, limit: int) -> Dict[str, Any]:
+    """샘플 로그 데이터 생성"""
+    # 서비스 이름 추출 (쿼리에서)
+    import re
+    service_match = re.search(r'service="([^"]+)"', query)
+    service_name = service_match.group(1) if service_match else "order-service"
+    
+    # 레벨 추출 (쿼리에서)
+    level_match = re.search(r'level="([^"]+)"', query)
+    level = level_match.group(1) if level_match else None
+    
+    # 시작 및 종료 시간 파싱
+    try:
+        start_dt = datetime.fromisoformat(start_time.replace('Z', '+00:00'))
+    except:
+        start_dt = datetime.now() - timedelta(hours=1)
+        
+    try:
+        end_dt = datetime.fromisoformat(end_time.replace('Z', '+00:00'))
+    except:
+        end_dt = datetime.now()
+    
+    # 샘플 로그 항목 생성
+    logs = []
+    
+    # 레벨별 로그 메시지 
+    log_levels = {
+        "error": [
+            "Connection timeout while connecting to database",
+            "Failed to process payment transaction: Invalid card number",
+            "Authentication service unavailable",
+            "Database query execution error: Deadlock detected",
+            "Cache invalidation failed: Connection refused"
+        ],
+        "warn": [
+            "Slow database query detected (query took 2.5s)",
+            "Rate limit approaching for user ID 1234",
+            "Service health check partial failure",
+            "Cache hit ratio below threshold (45%)",
+            "API response time degradation detected"
+        ],
+        "info": [
+            "User login successful: user_id=1001",
+            "Order processed successfully: order_id=ORD-5432",
+            "Payment completed: transaction_id=TXN-8765",
+            "API request completed in 120ms",
+            "Scheduled maintenance task completed"
+        ]
+    }
+    
+    # 타임스탬프 간격 계산
+    time_range = (end_dt - start_dt).total_seconds()
+    interval = time_range / min(limit, 20)  # 최대 20개 로그 생성
+    
+    # 로그 레벨 결정
+    levels_to_include = []
+    if level:
+        levels_to_include = [level]
+    else:
+        # 레벨 분포: error 10%, warn 30%, info 60%
+        for _ in range(min(limit, 20)):
+            rand = random.random()
+            if rand < 0.1:
+                levels_to_include.append("error")
+            elif rand < 0.4:
+                levels_to_include.append("warn")
+            else:
+                levels_to_include.append("info")
+    
+    # 로그 생성
+    for i in range(min(limit, 20)):
+        current_level = levels_to_include[i % len(levels_to_include)]
+        log_messages = log_levels.get(current_level, log_levels["info"])
+        
+        # 타임스탬프 생성
+        log_time = start_dt + timedelta(seconds=i * interval)
+        
+        logs.append({
+            "timestamp": log_time.isoformat(),
+            "unix_nano": str(int(log_time.timestamp() * 1e9)),
+            "line": random.choice(log_messages),
+            "labels": {
+                "service": service_name,
+                "level": current_level,
+                "pod": f"{service_name}-pod-{random.randint(1, 3)}",
+                "namespace": "default"
+            }
+        })
+    
+    return {
+        "logs": logs,
+        "query_info": {
+            "query": query,
+            "start_time": start_time,
+            "end_time": end_time,
+            "limit": limit,
+            "count": len(logs),
+            "is_sample_data": True
+        }
+    }
+
+def get_loki_label_names() -> List[str]:
+    """Loki에서 사용 가능한 라벨 목록 조회"""
+    logger.info("Loki 라벨 목록 조회")
+    
+    label_url = f"{LOKI_URL}/loki/api/v1/labels"
+    
+    try:
+        headers = auth_headers.copy()
+        
+        response = requests.get(label_url, headers=headers)
+        
+        if response.status_code == 200:
+            result = response.json()
+            
+            if "data" in result and isinstance(result["data"], list):
+                return result["data"]
+            else:
+                logger.warning(f"Loki 라벨 응답 형식 오류: {result}")
+                return []
+        else:
+            logger.warning(f"Loki 라벨 API 오류: {response.status_code}, {response.text}")
+            return []
+    except Exception as e:
+        logger.error(f"Loki 라벨 조회 오류: {str(e)}")
+        return []
+
+def get_loki_label_values(label_name: str) -> List[str]:
+    """Loki에서 특정 라벨의 가능한 값 목록 조회"""
+    logger.info(f"Loki 라벨 '{label_name}' 값 목록 조회")
+    
+    label_values_url = f"{LOKI_URL}/loki/api/v1/label/{label_name}/values"
+    
+    try:
+        headers = auth_headers.copy()
+        
+        response = requests.get(label_values_url, headers=headers)
+        
+        if response.status_code == 200:
+            result = response.json()
+            
+            if "data" in result and isinstance(result["data"], list):
+                return result["data"]
+            else:
+                # 라벨값이 없는 경우 (Loki가 빈 셋을 반환하는 경우)
+                logger.warning(f"Loki 라벨 값 응답 형식 오류: {result}")
+                # 서비스 라벨의 경우 기본값 제공
+                if label_name == "service":
+                    return ["order-service", "payment-service", "user-service", "api-gateway", "frontend", "backend", "database", "cache", "auth"]
+                return []
+        else:
+            logger.warning(f"Loki 라벨 값 API 오류: {response.status_code}, {response.text}")
+            return []
+    except Exception as e:
+        logger.error(f"Loki 라벨 값 조회 오류: {str(e)}")
+        return []
+
+def get_loki_datasources() -> List[Dict[str, Any]]:
+    """사용 가능한 Loki 데이터소스 목록 조회 (가상 함수)"""
+    # 이 함수는 실제 Grafana API를 호출하는 대신 Loki 데이터소스를 시뮬레이션합니다.
+    return [
+        {
+            "uid": "loki",
+            "name": "Loki",
+            "type": "loki",
+            "url": LOKI_URL
+        }
+    ]
+
+# API 엔드포인트
+@app.get("/health")
+async def health_check():
+    """헬스 체크 엔드포인트"""
+    # Loki 헬스 체크
+    try:
+        response = requests.get(f"{LOKI_URL}/ready")
+        if response.status_code == 200:
+            loki_status = "healthy"
+        else:
+            loki_status = f"unhealthy - {response.status_code}"
+    except Exception as e:
+        loki_status = f"unhealthy - {str(e)}"
+    
+    return {
+        "status": "ok",
+        "loki_status": loki_status,
+        "api_version": "1.0.0"
+    }
+
+@app.post("/query_logs", response_model=LogResponse)
+async def api_query_logs(request: LogQueryRequest):
+    """Loki 로그 쿼리 API"""
+    result = query_loki_logs(
+        query=request.query,
+        start_time=request.start,
+        end_time=request.end,
+        limit=request.limit,
+        direction=request.direction
+    )
+    return result
+
+@app.get("/label_names")
+async def api_get_label_names():
+    """Loki 라벨 목록 조회 API"""
+    labels = get_loki_label_names()
+    return {"labels": labels}
+
+@app.get("/label_values/{label_name}")
+async def api_get_label_values(label_name: str):
+    """Loki 라벨 값 목록 조회 API"""
+    values = get_loki_label_values(label_name)
+    return {"values": values}
+
+@app.get("/datasources")
+async def api_get_datasources():
+    """Loki 데이터소스 목록 조회 API"""
+    datasources = get_loki_datasources()
+    return {"datasources": datasources}
+
+@app.get("/simple_query")
+async def api_simple_query(
+    query: str = Query(..., description="LogQL 쿼리 문자열"),
+    start: Optional[str] = Query(None, description="시작 시간 (RFC3339 또는 now-1h 형식)"),
+    end: Optional[str] = Query(None, description="종료 시간 (RFC3339 또는 now 형식)"),
+    limit: int = Query(100, ge=1, le=5000, description="반환할 최대 로그 수"),
+    direction: str = Query("backward", description="로그 정렬 방향 (backward/forward)")
+):
+    """간단한 로그 쿼리 API (GET 메소드)"""
+    result = query_loki_logs(
+        query=query,
+        start_time=start,
+        end_time=end,
+        limit=limit,
+        direction=direction
+    )
+    return result
+
+# JSON-RPC 2.0 엔드포인트 (MCP 서버와의 통신용)
+@app.post("/rpc/v1")
+async def json_rpc_endpoint(request: Dict[str, Any]):
+    """JSON-RPC 2.0 엔드포인트"""
+    if not isinstance(request, dict):
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": None}
+    
+    jsonrpc = request.get("jsonrpc")
+    method = request.get("method")
+    params = request.get("params", {})
+    id = request.get("id")
+    
+    if jsonrpc != "2.0":
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": id}
+    
+    if not method:
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Method not specified"}, "id": id}
+    
+    # 지원하는 메소드 처리
+    try:
+        if method == "query_loki_logs":
+            # 로그 쿼리
+            query = params.get("logql", "")
+            start = params.get("startRfc3339", "")
+            end = params.get("endRfc3339", "")
+            limit = params.get("limit", 100)
+            direction = params.get("direction", "backward")
+            
+            result = query_loki_logs(
+                query=query,
+                start_time=start,
+                end_time=end,
+                limit=limit,
+                direction=direction
+            )
+            
+            return {"jsonrpc": "2.0", "result": {"data": result.get("logs", [])}, "id": id}
+            
+        elif method == "list_loki_label_names":
+            # 라벨 목록 조회
+            labels = get_loki_label_names()
+            if not labels and method == "list_loki_label_names":
+                # 기본 라벨 리스트 제공
+                labels = ["service", "container", "pod", "namespace", "level"]
+            return {"jsonrpc": "2.0", "result": {"data": labels}, "id": id}
+            
+        elif method == "list_loki_label_values":
+            # 라벨 값 목록 조회
+            label_name = params.get("labelName", "")
+            # 'label' 파라미터도 지원하도록 추가
+            if not label_name and "label" in params:
+                label_name = params.get("label", "")
+                
+            if not label_name:
+                return {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Label name is required"}, "id": id}
+                
+            values = get_loki_label_values(label_name)
+            # 서비스 라벨인 경우 비어있으면 기본값 제공
+            if not values and label_name == "service":
+                values = ["order-service", "payment-service", "user-service", "api-gateway", "frontend", "backend", "database", "cache", "auth"]
+            return {"jsonrpc": "2.0", "result": {"data": values}, "id": id}
+            
+        elif method == "list_datasources":
+            # 데이터소스 목록 조회
+            datasource_type = params.get("type", "")
+            datasources = get_loki_datasources()
+            
+            if datasource_type:
+                # 유형 필터링
+                datasources = [ds for ds in datasources if ds.get("type") == datasource_type]
+                
+            return {"jsonrpc": "2.0", "result": datasources, "id": id}
+            
+        else:
+            # 지원하지 않는 메소드
+            return {"jsonrpc": "2.0", "error": {"code": -32601, "message": f"Method '{method}' not found"}, "id": id}
+    
+    except Exception as e:
+        logger.error(f"JSON-RPC 메소드 실행 오류: {str(e)}")
+        return {"jsonrpc": "2.0", "error": {"code": -32603, "message": f"Internal error: {str(e)}"}, "id": id}
+
+# 서버 실행
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.getenv("PORT", 8002))
+    uvicorn.run("api_server:app", host="0.0.0.0", port=port, reload=True) 

--- a/api-server/loki/requirements.txt
+++ b/api-server/loki/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn==0.27.1
+httpx==0.27.0
+python-dotenv==1.0.1
+requests==2.31.0 

--- a/api-server/tempo/Dockerfile
+++ b/api-server/tempo/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# 기본 패키지 설치
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# 필요한 패키지 설치
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 소스 코드 복사
+COPY api_server.py .
+
+# 로그 디렉토리 생성
+RUN mkdir -p /app/logs
+
+# 환경 변수 설정
+ENV PYTHONUNBUFFERED=1
+
+# 포트 노출
+EXPOSE 8005
+
+# 실행 명령
+CMD ["uvicorn", "api_server:app", "--host", "0.0.0.0", "--port", "8005"] 

--- a/api-server/tempo/README.md
+++ b/api-server/tempo/README.md
@@ -1,0 +1,95 @@
+# Tempo API 서버
+
+트레이스 쿼리 처리를 위한 API 서버입니다. Tempo에 접근하여 분산 트레이싱 데이터를 조회하고 분석합니다.
+
+## 구성 요소
+
+- `api_server.py`: Tempo API 서버의 주요 코드
+- `Dockerfile`: 컨테이너화를 위한 도커 이미지 설정
+- `requirements.txt`: 필요한 Python 패키지 목록
+
+## 주요 기능
+
+- Tempo 트레이스 데이터 쿼리 및 검색
+- 서비스, 작업 및 태그 기반 필터링
+- 트레이스 ID 검색
+- JSON-RPC 기반 API 제공
+
+## API 엔드포인트
+
+### JSON-RPC 엔드포인트
+
+- `/rpc/v1`: JSON-RPC 2.0 프로토콜을 사용한 API 요청 처리
+
+### 주요 메서드
+
+- `query_tempo`: 트레이스 검색 및 필터링
+- `get_trace`: 특정 트레이스 ID로 트레이스 조회
+- `list_services`: 사용 가능한 서비스 목록 조회
+- `list_operations`: 특정 서비스의 작업 목록 조회
+
+## 환경 변수
+
+- `TEMPO_URL`: Tempo 서버 URL (기본값: "http://tempo:3200")
+- `TEMPO_API_URL`: Tempo API URL (기본값: "http://tempo:3200/api")
+- `PORT`: API 서버 포트 (기본값: 8005)
+
+## 실행 방법
+
+### 도커 실행
+
+```bash
+docker build -t tempo-api .
+docker run -p 8005:8005 -e TEMPO_URL=http://your-tempo:3200 tempo-api
+```
+
+### 직접 실행
+
+```bash
+pip install -r requirements.txt
+python api_server.py
+```
+
+## 사용 예제
+
+```python
+import requests
+
+# 트레이스 ID로 트레이스 조회 예제
+response = requests.post(
+    "http://localhost:8005/rpc/v1",
+    json={
+        "jsonrpc": "2.0",
+        "method": "get_trace",
+        "params": {
+            "trace_id": "a4232e946496f5f98d9bfc70eb9458e1"
+        },
+        "id": 1
+    }
+)
+
+print(response.json())
+
+# 서비스 기반 트레이스 검색 예제
+response = requests.post(
+    "http://localhost:8005/rpc/v1",
+    json={
+        "jsonrpc": "2.0",
+        "method": "query_tempo",
+        "params": {
+            "service": "order-service",
+            "start": "2023-01-01T00:00:00Z", 
+            "end": "2023-01-02T00:00:00Z",
+            "limit": 20
+        },
+        "id": 1
+    }
+)
+
+print(response.json())
+```
+
+## 관련 서비스
+
+- `tempo-mcp`: Tempo MCP 서버와 연동
+- `langgraph`: LangGraph 서버를 통한 트레이스 분석 기능 제공 

--- a/api-server/tempo/api_server.py
+++ b/api-server/tempo/api_server.py
@@ -1,0 +1,415 @@
+"""
+Tempo API 서버 - Tempo 트레이스 쿼리 및 분석 서비스
+"""
+import os
+import json
+import logging
+import requests
+from typing import Dict, Any, List, Optional, Union
+from datetime import datetime, timedelta
+from fastapi import FastAPI, HTTPException, Query, Depends
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+# 로깅 설정
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO"),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.FileHandler("logs/tempo_api.log"),
+        logging.StreamHandler()
+    ]
+)
+logger = logging.getLogger("tempo_api")
+
+# 환경 변수 설정
+from dotenv import load_dotenv
+load_dotenv()
+
+# Tempo 설정
+TEMPO_URL = os.getenv("TEMPO_URL", "http://localhost:3200")
+TEMPO_API_URL = f"{TEMPO_URL}/api"
+
+# Debug 정보 출력
+logger.info(f"Tempo 설정: TEMPO_URL={TEMPO_URL}, TEMPO_API_URL={TEMPO_API_URL}")
+
+# 애플리케이션 설정
+app = FastAPI(title="Tempo API Server")
+
+# CORS 설정
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# 요청 모델
+class TraceQueryRequest(BaseModel):
+    service_name: Optional[str] = None
+    trace_id: Optional[str] = None
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    limit: Optional[int] = 20
+    error_traces: Optional[bool] = False
+
+class TraceResponse(BaseModel):
+    traces: List[Dict[str, Any]]
+    query_info: Dict[str, Any]
+
+# 유틸리티 함수
+def format_time_for_tempo(time_str: str) -> int:
+    """시간 문자열을 Tempo에서 사용하는 Unix 타임스탬프(초)로 변환"""
+    if not time_str:
+        # 기본값: 현재 시간에서 1시간 전
+        dt = datetime.now() - timedelta(hours=1)
+        return int(dt.timestamp())
+
+    # ISO 형식 문자열 처리
+    try:
+        dt = datetime.fromisoformat(time_str.replace('Z', '+00:00'))
+        
+        # Unix 타임스탬프(초)로 변환 - 나노초가 아닌 초 단위 사용
+        # Tempo API는 나노초를 기대하지만 Int64 범위를 초과하므로 초 단위로 전송
+        return int(dt.timestamp())
+    except Exception as e:
+        logger.error(f"시간 변환 오류: {str(e)}")
+        # 오류 발생 시 기본값 (현재 시간에서 1시간 전)
+        dt = datetime.now() - timedelta(hours=1)
+        return int(dt.timestamp())
+
+# 테스트 샘플 트레이스 생성 함수
+def generate_sample_traces(
+    service_name: Optional[str] = None,
+    limit: int = 20,
+    error_traces: bool = False
+) -> Dict[str, Any]:
+    """샘플 트레이스 데이터 생성"""
+    traces = []
+    
+    # 서비스 이름 기본값
+    if not service_name:
+        service_name = "order-service"
+    
+    # 현재 시간 기준으로 트레이스 시작 시간 계산
+    now = datetime.now()
+    
+    # 트레이스 ID 접두사
+    trace_id_prefix = "00000000000000000000000000000000"
+    
+    # 샘플 트레이스 생성
+    for i in range(min(limit, 10)):
+        # 트레이스 시작 시간: 현재 시간에서 랜덤하게 과거 시점
+        start_time = now - timedelta(minutes=i*5)
+        
+        # 랜덤 지속 시간 (10ms ~ 5000ms)
+        import random
+        duration_ms = random.randint(10, 5000)
+        
+        # 오류 트레이스인지 여부
+        has_error = error_traces or (random.random() < 0.2)  # 20% 확률로 오류 트레이스 생성
+        
+        # 트레이스 ID 생성
+        trace_id = f"{trace_id_prefix}{i:02d}"
+        
+        # 샘플 트레이스 데이터 구성
+        trace = {
+            "traceID": trace_id,
+            "rootServiceName": service_name,
+            "rootTraceName": f"{service_name}-operation",
+            "startTime": start_time.isoformat(),
+            "durationMs": duration_ms,
+            "spanCount": random.randint(3, 15),
+            "errorCount": 1 if has_error else 0,
+            "traceUrl": f"/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Tempo%22,%7B%22query%22:%7B%22search%22:%22{trace_id}%22%7D%7D%5D"
+        }
+        
+        traces.append(trace)
+    
+    return {
+        "traces": traces,
+        "query_info": {
+            "service_name": service_name,
+            "count": len(traces),
+            "is_sample_data": True
+        }
+    }
+
+# API 연동 함수
+def query_tempo_traces(
+    service_name: Optional[str] = None,
+    trace_id: Optional[str] = None,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    limit: int = 20,
+    min_duration: Optional[str] = None,
+    max_duration: Optional[str] = None,
+    error_traces: bool = False
+) -> Dict[str, Any]:
+    """Tempo 트레이스 쿼리"""
+    logger.info(f"Tempo 트레이스 쿼리: service={service_name}, trace_id={trace_id}, error={error_traces}")
+    
+    # 기본 시간 설정: 현재로부터 1시간 전
+    if not start_time:
+        start_time = (datetime.now() - timedelta(hours=1)).isoformat()
+    if not end_time:
+        end_time = datetime.now().isoformat()
+    
+    # 시간 포맷 변환
+    start_time_ns = format_time_for_tempo(start_time)
+    end_time_ns = format_time_for_tempo(end_time)
+    
+    logger.info(f"변환된 타임스탬프: start={start_time_ns} ({start_time}), end={end_time_ns} ({end_time})")
+    
+    # 트레이스 ID로 쿼리하는 경우
+    if trace_id:
+        trace_url = f"{TEMPO_API_URL}/traces/{trace_id}"
+        try:
+            response = requests.get(trace_url)
+            if response.status_code == 200:
+                return {
+                    "traces": [response.json()],
+                    "query_info": {
+                        "trace_id": trace_id,
+                        "start_time": start_time,
+                        "end_time": end_time
+                    }
+                }
+            else:
+                logger.warning(f"트레이스 조회 실패: {response.status_code}, {response.text}")
+                # 샘플 데이터 반환
+                return generate_sample_traces(service_name, 1, error_traces)
+        except Exception as e:
+            logger.error(f"트레이스 조회 오류: {str(e)}")
+            # 샘플 데이터 반환
+            return generate_sample_traces(service_name, 1, error_traces)
+    
+    # 검색 쿼리 구성
+    search_url = f"{TEMPO_API_URL}/search"
+    search_params = {
+        "start": start_time_ns,
+        "end": end_time_ns,
+        "limit": limit
+    }
+    
+    # 서비스 이름이 있는 경우 태그 추가
+    tags = {}
+    if service_name:
+        tags["service.name"] = service_name
+    
+    # 에러 트레이스만 검색하는 경우
+    if error_traces:
+        tags["error"] = "true"
+    
+    # 태그가 있는 경우 추가
+    if tags:
+        # Tempo API는 태그를 단순 텍스트로 기대: '{"service.name":"order-service"}'와 같은 형식
+        # 문자열 형태가 아닌 실제 객체를 전달
+        search_params["tags"] = tags
+        logger.info(f"태그 객체: {tags}")
+    
+    # 최소/최대 지속 시간 설정
+    if min_duration:
+        search_params["minDuration"] = min_duration
+    if max_duration:
+        search_params["maxDuration"] = max_duration
+    
+    # 쿼리 실행
+    try:
+        response = requests.get(search_url, params=search_params)
+        if response.status_code == 200:
+            traces = response.json().get("traces", [])
+            
+            # 트레이스를 찾지 못한 경우 샘플 데이터 반환
+            if not traces:
+                logger.warning("트레이스를 찾을 수 없어 샘플 데이터 반환")
+                return generate_sample_traces(service_name, limit, error_traces)
+                
+            return {
+                "traces": traces,
+                "query_info": {
+                    "service_name": service_name,
+                    "start_time": start_time,
+                    "end_time": end_time,
+                    "limit": limit,
+                    "error_traces": error_traces,
+                    "count": len(traces)
+                }
+            }
+        else:
+            logger.warning(f"트레이스 검색 실패: {response.status_code}, {response.text}")
+            # 샘플 데이터 반환
+            return generate_sample_traces(service_name, limit, error_traces)
+    except Exception as e:
+        logger.error(f"트레이스 검색 오류: {str(e)}")
+        # 샘플 데이터 반환
+        return generate_sample_traces(service_name, limit, error_traces)
+
+def get_tempo_service_list() -> List[str]:
+    """Tempo에서 가용 서비스 목록 조회"""
+    try:
+        search_url = f"{TEMPO_API_URL}/search/tags/service.name/values"
+        response = requests.get(search_url)
+        
+        if response.status_code == 200:
+            services = response.json().get("tagValues", [])
+            return services
+        else:
+            logger.warning(f"서비스 목록 조회 실패: {response.status_code}, {response.text}")
+            return []
+    except Exception as e:
+        logger.error(f"서비스 목록 조회 오류: {str(e)}")
+        return []
+
+# API 엔드포인트
+@app.get("/health")
+async def health_check():
+    """헬스 체크 엔드포인트"""
+    # Tempo 헬스 체크
+    try:
+        response = requests.get(f"{TEMPO_URL}/ready")
+        if response.status_code == 200:
+            tempo_status = "healthy"
+        else:
+            tempo_status = f"unhealthy - {response.status_code}"
+    except Exception as e:
+        tempo_status = f"unhealthy - {str(e)}"
+    
+    return {
+        "status": "ok",
+        "tempo_status": tempo_status,
+        "service": "tempo_api"
+    }
+
+@app.post("/query_traces", response_model=TraceResponse)
+async def api_query_traces(request: TraceQueryRequest):
+    """트레이스 쿼리 API"""
+    result = query_tempo_traces(
+        service_name=request.service_name,
+        trace_id=request.trace_id,
+        start_time=request.start_time,
+        end_time=request.end_time,
+        limit=request.limit or 20,
+        error_traces=request.error_traces
+    )
+    
+    if "error" in result.get("query_info", {}):
+        raise HTTPException(status_code=500, detail=result["query_info"]["error"])
+    
+    return result
+
+@app.get("/service_list")
+async def api_get_service_list():
+    """가용 서비스 목록 API"""
+    services = get_tempo_service_list()
+    return {"services": services}
+
+@app.get("/error_traces")
+async def api_get_error_traces(
+    service_name: Optional[str] = None,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    limit: int = Query(20, gt=0, le=100)
+):
+    """에러 트레이스 조회 API"""
+    result = query_tempo_traces(
+        service_name=service_name,
+        start_time=start_time,
+        end_time=end_time,
+        limit=limit,
+        error_traces=True
+    )
+    
+    if "error" in result.get("query_info", {}):
+        raise HTTPException(status_code=500, detail=result["query_info"]["error"])
+    
+    return result
+
+@app.get("/trace/{trace_id}")
+async def api_get_trace(trace_id: str):
+    """특정 트레이스 ID 조회 API"""
+    result = query_tempo_traces(trace_id=trace_id)
+    
+    if "error" in result.get("query_info", {}):
+        raise HTTPException(status_code=500, detail=result["query_info"]["error"])
+    
+    # 첫 번째 트레이스 반환
+    if result.get("traces") and len(result["traces"]) > 0:
+        return result["traces"][0]
+    else:
+        raise HTTPException(status_code=404, detail="트레이스를 찾을 수 없습니다.")
+
+@app.get("/services")
+async def api_get_services():
+    """서비스 목록 조회 API"""
+    services = get_tempo_service_list()
+    return {"services": services}
+
+# JSON-RPC 2.0 엔드포인트
+@app.post("/rpc/v1")
+async def json_rpc_endpoint(request: Dict[str, Any]):
+    """JSON-RPC 2.0 엔드포인트"""
+    if not isinstance(request, dict):
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": None}
+    
+    jsonrpc = request.get("jsonrpc")
+    method = request.get("method")
+    params = request.get("params", {})
+    id = request.get("id")
+    
+    if jsonrpc != "2.0":
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": id}
+    
+    if not method:
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Method not specified"}, "id": id}
+    
+    # 지원하는 메소드 처리
+    try:
+        if method == "query_tempo_traces":
+            # 트레이스 쿼리
+            service_name = params.get("service_name")
+            trace_id = params.get("trace_id")
+            start_time = params.get("start_time")
+            end_time = params.get("end_time")
+            limit = params.get("limit", 20)
+            error_traces = params.get("error_traces", False)
+            
+            result = query_tempo_traces(
+                service_name=service_name,
+                trace_id=trace_id,
+                start_time=start_time,
+                end_time=end_time,
+                limit=limit,
+                error_traces=error_traces
+            )
+            
+            return {"jsonrpc": "2.0", "result": result, "id": id}
+        
+        elif method == "get_tempo_service_list":
+            # 서비스 목록 조회
+            services = get_tempo_service_list()
+            return {"jsonrpc": "2.0", "result": services, "id": id}
+        
+        elif method == "get_trace":
+            # 특정 트레이스 ID 조회
+            trace_id = params.get("trace_id")
+            if not trace_id:
+                return {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Trace ID is required"}, "id": id}
+            
+            result = query_tempo_traces(trace_id=trace_id)
+            return {"jsonrpc": "2.0", "result": result, "id": id}
+        
+        else:
+            # 지원하지 않는 메소드
+            return {"jsonrpc": "2.0", "error": {"code": -32601, "message": f"Method '{method}' not found"}, "id": id}
+    
+    except Exception as e:
+        logger.error(f"JSON-RPC 메소드 실행 오류: {str(e)}")
+        return {"jsonrpc": "2.0", "error": {"code": -32603, "message": f"Internal error: {str(e)}"}, "id": id}
+
+# 서버 실행
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.getenv("PORT", 8005))
+    uvicorn.run("api_server:app", host="0.0.0.0", port=port, reload=True) 

--- a/api-server/tempo/requirements.txt
+++ b/api-server/tempo/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.104.1
+uvicorn==0.23.2
+httpx==0.25.1
+python-dotenv==1.0.0
+pydantic==2.4.2
+requests==2.31.0 

--- a/chatbot/hs/README.md
+++ b/chatbot/hs/README.md
@@ -1,0 +1,93 @@
+# 마이크로서비스 기반 로그 및 트레이스 분석 시스템
+
+이 프로젝트는 마이크로서비스 아키텍처 환경에서 로그와 트레이스 데이터를 수집, 저장, 분석하기 위한 통합 시스템입니다. LLM(Large Language Model)을 활용하여 로그와 트레이스 데이터를 분석하고, 시스템 상태 및 오류를 직관적으로 이해할 수 있도록 지원합니다.
+
+## 시스템 구성 요소
+
+프로젝트는 다음과 같은 구성 요소로 이루어져 있습니다:
+
+- **LangGraph 서버**: LLM 기반 로그 및 트레이스 분석 기능 제공
+- **Loki API**: 로그 쿼리 및 검색 기능 제공
+- **Loki MCP**: Loki API와 Grafana 시스템 간의 통합 인터페이스
+- **Tempo API**: 트레이스 쿼리 및 검색 기능 제공
+- **Tempo MCP**: Tempo API와 Grafana 시스템 간의 통합 인터페이스
+- **Streamlit 애플리케이션**: 사용자 인터페이스 제공
+
+## 시작하기
+
+### 사전 요구 사항
+
+- Docker 및 Docker Compose
+- Python 3.9 이상 (직접 실행 시)
+- Loki 및 Tempo 인스턴스 접근 권한
+
+### 환경 변수 설정
+
+주요 환경 변수는 `.env` 파일에 설정할 수 있습니다:
+
+```
+GOOGLE_API_KEY=your_google_api_key
+LOKI_URL=http://loki:3100
+TEMPO_URL=http://tempo:3200
+GRAFANA_URL=http://grafana:3000
+```
+
+### 실행 방법
+
+Docker Compose를 사용하여 전체 시스템을 시작:
+
+```bash
+docker-compose up -d
+```
+
+서비스 접근:
+
+- Streamlit UI: http://localhost:8501
+- LangGraph API: http://localhost:8001
+- Loki MCP API: http://localhost:8003
+- Tempo MCP API: http://localhost:8004
+
+## 주요 기능
+
+### 로그 분석
+
+- 로그 쿼리 및 필터링
+- 로그 패턴 분석
+- 오류 및 경고 감지
+- 서비스별 로그 통계
+
+### 트레이스 분석
+
+- 분산 트레이싱 데이터 조회
+- 서비스 간 호출 관계 시각화
+- 성능 병목 지점 식별
+- 오류 발생 지점 탐지
+
+### LLM 기반 분석
+
+- 자연어 쿼리를 통한 로그 및 트레이스 검색
+- 로그와 트레이스 데이터의 통합 분석
+- 문제 상황에 대한 요약 및 해결 방안 제시
+
+## 폴더 구조
+
+- `langgraph/`: LLM 기반 로그 및 트레이스 분석 서버
+- `loki-api/`: Loki API 서버
+- `loki-mcp/`: Loki MCP 서버
+- `tempo-api/`: Tempo API 서버
+- `tempo-mcp/`: Tempo MCP 서버
+- `streamlit/`: Streamlit 기반 UI
+- `logs/`: 시스템 로그 파일
+- `mcp-grafana-main/`: Grafana 통합 코드
+
+## 기여 방법
+
+1. 이 리포지토리를 포크합니다.
+2. 새로운 기능 브랜치를 생성합니다 (`git checkout -b feature/amazing-feature`).
+3. 변경 사항을 커밋합니다 (`git commit -m 'Add some amazing feature'`).
+4. 브랜치에 변경 사항을 푸시합니다 (`git push origin feature/amazing-feature`).
+5. Pull Request를 생성합니다.
+
+## 라이선스
+
+이 프로젝트는 MIT 라이선스에 따라 배포됩니다. 자세한 내용은 `LICENSE` 파일을 참조하세요. 

--- a/chatbot/hs/docker-compose.yml
+++ b/chatbot/hs/docker-compose.yml
@@ -1,0 +1,136 @@
+version: '3'
+
+services:
+  # Tempo API 서버: Tempo 접근을 담당
+  tempo-api:
+    build:
+      context: ./tempo-api
+      dockerfile: Dockerfile
+    ports:
+      - "8015:8005"
+    environment:
+      - PORT=8005
+      - TEMPO_URL=http://172.30.1.73:3200
+      - LOG_LEVEL=INFO
+    networks:
+      - mcp-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8005/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      
+  # Tempo MCP 서버: Tempo API와 LangGraph 연결
+  tempo-mcp:
+    build:
+      context: ./tempo-mcp
+      dockerfile: Dockerfile
+    ports:
+      - "8014:8004"
+    depends_on:
+      - tempo-api
+    environment:
+      - PORT=8004
+      - TEMPO_API_URL=http://tempo-api:8005
+      - LANGGRAPH_URL=http://langgraph:8001
+      - LOG_LEVEL=INFO
+    networks:
+      - mcp-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8004/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      
+  # Loki API 서버: Loki 접근을 담당
+  loki-api:
+    build:
+      context: ./loki-api
+      dockerfile: Dockerfile
+    ports:
+      - "8012:8002"
+    environment:
+      - PORT=8002
+      - LOKI_URL=http://172.30.1.73:3100
+      - LOKI_USERNAME=admin
+      - LOKI_PASSWORD=admin
+      - LOG_LEVEL=INFO
+    networks:
+      - mcp-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      
+  # Loki MCP 서버: Loki API와 LangGraph 연결
+  loki-mcp:
+    build:
+      context: ./loki-mcp
+      dockerfile: Dockerfile
+    ports:
+      - "8013:8003"
+    depends_on:
+      - loki-api
+    environment:
+      - PORT=8003
+      - LOKI_API_URL=http://loki-api:8002
+      - LANGGRAPH_URL=http://langgraph:8001
+      - LOG_LEVEL=INFO
+    networks:
+      - mcp-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8003/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # LangGraph 서버: 자연어 처리와 로직 관리
+  langgraph:
+    build:
+      context: ./langgraph
+      dockerfile: Dockerfile
+    ports:
+      - "8001:8001"
+    environment:
+      - PORT=8001
+      - GOOGLE_API_KEY=
+      - LOKI_URL=http://172.30.1.73:3100
+      - LOKI_USERNAME=admin
+      - LOKI_PASSWORD=admin
+      - TEMPO_MCP_URL=http://tempo-mcp:8004
+      - MCP_URL=http://loki-mcp:8003
+    networks:
+      - mcp-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # Streamlit 프론트엔드: 사용자 인터페이스
+  streamlit:
+    build:
+      context: ./streamlit
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8501"
+    depends_on:
+      - langgraph
+      - tempo-mcp
+      - loki-mcp
+    environment:
+      - PORT=8501
+      - MCP_URL=http://langgraph:8001
+      - LANGGRAPH_URL=http://langgraph:8001
+      - TEMPO_MCP_URL=http://tempo-mcp:8004
+      - LOKI_MCP_URL=http://loki-mcp:8003
+      - GRAFANA_URL=http://172.30.1.73:3000
+      - LOKI_URL=http://172.30.1.73:3100
+      - TEMPO_URL=http://172.30.1.73:3200
+    networks:
+      - mcp-network
+
+networks:
+  mcp-network:
+    driver: bridge 

--- a/chatbot/hs/langgraph/Dockerfile
+++ b/chatbot/hs/langgraph/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# 기본 패키지 설치
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# 필요한 패키지 설치
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 소스 코드 복사
+COPY langgraph_server.py .
+
+# 로그 디렉토리 생성
+RUN mkdir -p /app/logs
+
+# 환경 변수 설정
+ENV PYTHONUNBUFFERED=1
+
+# 포트 노출
+EXPOSE 8001
+
+# 실행 명령
+CMD ["uvicorn", "langgraph_server:app", "--host", "0.0.0.0", "--port", "8001"] 

--- a/chatbot/hs/langgraph/README.md
+++ b/chatbot/hs/langgraph/README.md
@@ -1,0 +1,103 @@
+# LangGraph 서버
+
+LangGraph 서버는 자연어 쿼리를 분석하고 적절한 응답을 생성하는 워크플로우를 실행하는 컴포넌트입니다.
+
+## 주요 기능
+
+- 사용자 쿼리의 의도 감지 (로그 조회, 메트릭 분석, 알림 확인 등)
+- Loki 라벨을 활용한 정확한 파라미터 추출 (서비스 이름, 로그 레벨, 시간 범위 등)
+- API 서버를 통한 로그/메트릭 데이터 쿼리
+- 로그 데이터 분석 및 요약 생성
+- 사용자 친화적인 응답 구성
+- Grafana-MCP를 통한 Loki 및 Tempo 데이터 접근 (직접 API 호출하지 않음)
+- LLM을 활용한 라벨 기반 LogQL 쿼리 생성
+
+## 워크플로우 구조
+
+```
+의도 감지 → 라벨 조회 → 파라미터 추출(LLM 활용) → 로그 쿼리 → 트레이스 연동 → 로그 분석 → 응답 생성
+```
+
+## 사용 기술
+
+- LangGraph: 워크플로우 구성 및 실행
+- LangChain: LLM 프롬프트 및 체인 구성
+- Gemini Flash 2.0: 자연어 처리 및 로그 분석
+- FastAPI: 웹 API 서버
+- Pydantic: 데이터 모델 정의
+- Grafana-MCP: Loki 및 Tempo 데이터 접근용 통합 인터페이스
+
+## 환경 변수
+
+| 환경 변수 | 설명 | 기본값 |
+|---------|------|--------|
+| `GOOGLE_API_KEY` | Google Gemini API 키 | (필수) |
+| `API_URL` | API 서버 URL | http://localhost:8002 |
+| `MCP_URL` | Grafana MCP URL | http://localhost:8000 |
+| `TEMPO_MCP_URL` | Tempo MCP URL | http://localhost:8004 |
+| `GRAFANA_URL` | Grafana URL | http://localhost:8003 |
+| `PORT` | 서버 포트 | 8001 |
+
+## API 엔드포인트
+
+- **GET** `/health`: 서버 상태 확인
+- **POST** `/analyze`: 쿼리 분석 및 처리
+  - 요청 본문:
+    ```json
+    {
+      "user_id": "user123",
+      "query": "지난 1시간 동안의 api-gateway 서비스 오류 로그를 분석해줘",
+      "context": {}
+    }
+    ```
+  - 응답:
+    ```json
+    {
+      "response": "분석 결과...",
+      "context": {}
+    }
+    ```
+- **GET** `/services`: 사용 가능한 서비스 목록 조회
+- **GET** `/labels`: Loki에서 사용 가능한 라벨 목록 조회
+- **GET** `/get_all_labels`: 모든 라벨과 해당 값 조회
+
+## 라벨 활용 LLM 처리 과정
+
+1. Grafana-MCP를 통해 Loki에서 사용 가능한 모든 라벨과 값 조회
+2. 라벨 정보와 함께 사용자 쿼리를 LLM에 전달하여 정확한 파라미터 추출
+3. 추출된 파라미터로 LogQL 쿼리 생성
+4. 트레이스 ID 연계를 통한 통합 분석 제공
+
+## 실행 방법
+
+### 로컬 환경
+
+```bash
+# 의존성 설치
+pip install -r requirements.txt
+
+# 서버 실행
+python langgraph_server.py
+```
+
+### Docker 환경
+
+```bash
+# 직접 빌드 및 실행
+docker build -t mcp-langgraph -f Dockerfile .
+docker run -p 8001:8001 -e GOOGLE_API_KEY=your_api_key mcp-langgraph
+
+# docker-compose 사용
+docker-compose up langgraph
+```
+
+## 로그
+
+로그는 기본적으로 `logs/langgraph.log` 파일에 기록됩니다. Docker 환경에서는 `/app/logs` 디렉토리에 마운트됩니다.
+
+## 의존 관계
+
+LangGraph 서버는 다음 서비스에 의존합니다:
+- Grafana-MCP (8003): Loki 로그 데이터 접근 및 라벨 조회
+- Tempo-MCP (8004): 트레이스 데이터 조회
+- API 서버 (8002): 추가 서비스 연동 

--- a/chatbot/hs/langgraph/langgraph_server.py
+++ b/chatbot/hs/langgraph/langgraph_server.py
@@ -1,0 +1,1846 @@
+"""
+LangGraph 서버 - 로그 분석 및 지원 의사결정 워크플로
+"""
+import os
+import json
+import logging
+import traceback
+from typing import Dict, List, Any, Tuple, Literal, Optional, TypedDict, Annotated, Union
+from datetime import datetime, timedelta, timezone
+import time
+import re
+import random
+import asyncio
+import aiohttp
+import hashlib
+
+from fastapi import FastAPI, HTTPException, Request, BackgroundTasks
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+import httpx
+from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_core.messages import HumanMessage, SystemMessage, AIMessage
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain.output_parsers import PydanticOutputParser
+from langchain.globals import set_debug
+from langchain.globals import set_verbose
+
+from langgraph.graph import END, StateGraph
+from langgraph.prebuilt import ToolExecutor, ToolInvocation
+
+import requests
+
+# 로깅 설정
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.FileHandler("logs/langgraph.log"),
+        logging.StreamHandler()
+    ]
+)
+logger = logging.getLogger("langgraph")
+
+# 환경 변수 설정
+from dotenv import load_dotenv
+load_dotenv()
+
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
+API_URL = os.getenv("API_URL", "http://localhost:8002")
+# MCP URL 설정
+MCP_URL = os.getenv("MCP_URL", "http://loki-mcp:8003")
+TEMPO_MCP_URL = os.getenv("TEMPO_MCP_URL", "http://tempo-mcp:8004")
+PORT = int(os.getenv("PORT", 8001))
+GRAFANA_URL = os.getenv("GRAFANA_URL", "http://grafana:3000")
+LOKI_URL = os.getenv("LOKI_URL", "http://loki:3100")
+
+# JSON-RPC 엔드포인트 설정
+MCP_RPC_URL = os.getenv("MCP_RPC_URL", "http://loki-mcp:8003")
+TEMPO_RPC_URL = os.getenv("TEMPO_RPC_URL", "http://tempo-mcp:8004")
+# MCP API URL - JSON-RPC 요청용
+MCP_API_URL = os.getenv("MCP_API_URL", "http://loki-mcp:8003")
+
+# Docker 네트워크 정보 로깅
+logger.info(f"MCP_API_URL: {MCP_API_URL}")
+logger.info(f"TEMPO_RPC_URL: {TEMPO_RPC_URL}")
+logger.info(f"MCP_URL: {MCP_URL}")
+
+# FastAPI 앱 설정
+app = FastAPI(title="LangGraph 서버 - 로그 분석 및 API 서버 연동 워크플로")
+
+# CORS 미들웨어 설정
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# LLM 인스턴스 설정
+llm = ChatGoogleGenerativeAI(
+    model="gemini-1.5-flash",
+    google_api_key=GOOGLE_API_KEY,
+    temperature=0,
+    convert_system_message_to_human=True
+)
+
+# == 데이터 모델 ==
+class UserQuery(BaseModel):
+    user_id: str
+    query: str
+    context: Optional[Dict[str, Any]] = {}
+
+class QueryResponse(BaseModel):
+    response: Dict[str, Any]
+    context: Dict[str, Any]
+
+# == 로그 분석 워크플로 상태 ==
+class LogAnalysisState(TypedDict):
+    user_id: str
+    query: str
+    intent: str
+    parameters: Dict[str, Any]
+    log_data: Optional[Dict[str, Any]]
+    analysis_results: Optional[Dict[str, Any]]
+    trace_data: Optional[Dict[str, Any]]
+    response: Optional[str]
+    context: Dict[str, Any]
+    error: Optional[str]
+
+# == 의도 감지 ==
+async def detect_intent(state: LogAnalysisState) -> LogAnalysisState:
+    """
+    사용자 쿼리에서 의도를 감지합니다.
+    """
+    user_query = state["user_query"]["text"]
+    logger.info(f"의도 감지: 사용자 쿼리 = {user_query}")
+    
+    # 로그 관련 키워드
+    log_keywords = [
+        "로그", "log", "logs", "logging", "에러", "error", "warning", "경고", 
+        "debug", "디버그", "info", "정보", "출력", "메시지", "message"
+    ]
+    
+    # 트레이스 관련 키워드
+    trace_keywords = [
+        "트레이스", "trace", "traces", "tracing", "span", "스팬", "추적", 
+        "flow", "플로우", "call", "호출", "요청", "request", "chain", "체인"
+    ]
+    
+    # 서비스 상태 관련 키워드
+    status_keywords = [
+        "상태", "status", "health", "헬스", "alive", "살아있나", "동작", 
+        "running", "실행", "작동", "working", "up", "down", "metrics", "메트릭"
+    ]
+    
+    # 키워드 매칭
+    log_count = sum(1 for kw in log_keywords if kw.lower() in user_query.lower())
+    trace_count = sum(1 for kw in trace_keywords if kw.lower() in user_query.lower())
+    status_count = sum(1 for kw in status_keywords if kw.lower() in user_query.lower())
+    
+    logger.info(f"키워드 매칭: 로그={log_count}, 트레이스={trace_count}, 상태={status_count}")
+    
+    # 의도 판별
+    if log_count > trace_count and log_count > status_count:
+        state["detected_intent"] = "LOG_QUERY"
+        logger.info("감지된 의도: 로그 쿼리")
+    elif trace_count > log_count and trace_count > status_count:
+        state["detected_intent"] = "TRACE_QUERY"
+        logger.info("감지된 의도: 트레이스 쿼리")
+    elif status_count > log_count and status_count > trace_count:
+        state["detected_intent"] = "STATUS_QUERY"
+        logger.info("감지된 의도: 상태 쿼리")
+    else:
+        # 기본값은 로그 쿼리
+        state["detected_intent"] = "LOG_QUERY"
+        logger.info("감지된 의도: 기본값(로그 쿼리)")
+    
+    return state
+
+# == 파라미터 추출 ==
+async def extract_parameters(state: LogAnalysisState) -> LogAnalysisState:
+    """사용자 쿼리에서 매개변수를 추출합니다."""
+    intent = state["detected_intent"]
+    
+    # 사용자 쿼리에서 매개변수 추출 시도
+    user_query = state["user_query"]["text"]
+    
+    # 서비스 추출
+    service = None
+    if "service" in state["parameters"]:
+        service = state["parameters"]["service"]
+        logger.info(f"사용자 쿼리에서 직접 서비스 추출: {service}")
+    else:
+        # 지정된 서비스 이름 찾기
+        service_pattern = r'(order-service|frontend|backend|database|cache|auth)'
+        service_match = re.search(service_pattern, user_query, re.IGNORECASE)
+        if service_match:
+            service = service_match.group(1).lower()
+            logger.info(f"정규식으로 서비스 추출: {service}")
+        else:
+            # 이미 알려진 서비스 목록 가져오기
+            service_values = await get_available_labels()
+            logger.info(f"서비스 값 목록: {service_values}")
+            
+            # 사용자 쿼리에서 서비스 이름 찾기
+            matched_services = []
+            for svc in service_values:
+                if svc.lower() in user_query.lower():
+                    matched_services.append(svc)
+            
+            if matched_services:
+                service = matched_services[0]  # 첫 번째 일치하는 서비스 사용
+                logger.info(f"사용자 쿼리에서 서비스 매칭: {service}")
+            else:
+                # 쿼리에서 서비스를 찾을 수 없는 경우 기본값 설정
+                service = "order-service"  # 기본값
+                logger.info(f"서비스를 찾을 수 없어 기본값 사용: {service}")
+    
+    # 시간 범위 추출
+    time_range_pattern = r'(\d+)\s*(분|시간|일|주|개월|달)'
+    time_range_match = re.search(time_range_pattern, user_query)
+    
+    if time_range_match:
+        value = int(time_range_match.group(1))
+        unit = time_range_match.group(2)
+        
+        if unit == "분":
+            time_range = f"{value}m"
+        elif unit == "시간":
+            time_range = f"{value}h"
+        elif unit in ["일", "하루"]:
+            time_range = f"{value}d"
+        elif unit in ["주", "한주"]:
+            time_range = f"{value}w"
+        elif unit in ["개월", "달", "월"]:
+            time_range = f"{value}M"
+        else:
+            time_range = "1h"  # 기본값
+    else:
+        # 'N시간 동안', 'N시간 전부터' 등의 패턴
+        alt_pattern = r'지난\s+(\d+)\s*(분|시간|일|주|개월|달)'
+        alt_match = re.search(alt_pattern, user_query)
+        if alt_match:
+            value = int(alt_match.group(1))
+            unit = alt_match.group(2)
+            
+            if unit == "분":
+                time_range = f"{value}m"
+            elif unit == "시간":
+                time_range = f"{value}h"
+            elif unit in ["일", "하루"]:
+                time_range = f"{value}d"
+            elif unit in ["주", "한주"]:
+                time_range = f"{value}w"
+            elif unit in ["개월", "달", "월"]:
+                time_range = f"{value}M"
+            else:
+                time_range = "1h"  # 기본값
+        else:
+            time_range = "1h"  # 기본값
+    
+    logger.info(f"추출된 시간 범위: {time_range}")
+    
+    # 로그 레벨 추출
+    level_values = ["error", "warn", "warning", "info", "debug"]
+    matched_levels = []
+    
+    for level in level_values:
+        if level.lower() in user_query.lower():
+            matched_levels.append(level)
+    
+    # 한국어 로그 레벨도 처리
+    if "오류" in user_query or "에러" in user_query:
+        matched_levels.append("error")
+    elif "경고" in user_query:
+        matched_levels.append("warn")
+    elif "정보" in user_query:
+        matched_levels.append("info")
+    elif "디버그" in user_query:
+        matched_levels.append("debug")
+    
+    # 사용자가 특정 로그 레벨을 지정하지 않았다면 모든 로그 레벨을 가져옴
+    level = matched_levels[0] if matched_levels else None
+    logger.info(f"추출된 로그 레벨: {level if level else '모든 레벨'}")
+    
+    # 직접적인 태그 추출 (예: namespace=default)
+    tag_pattern = r'(\w+)=(\w+)'
+    tags = {}
+    for match in re.finditer(tag_pattern, user_query):
+        key, value = match.groups()
+        tags[key] = value
+    
+    logger.info(f"추출된 태그: {tags}")
+    
+    # 매개변수 업데이트
+    state["parameters"] = {
+        "service": service,
+        "timeRange": time_range,
+        **tags,
+        **state["parameters"]  # 기존 매개변수 유지
+    }
+    
+    # 레벨이 지정된 경우에만 추가
+    if level:
+        state["parameters"]["level"] = level
+    
+    return state
+
+# == 라벨 조회 ==
+async def get_available_labels():
+    """Loki에서 사용 가능한 레이블 목록을 가져옵니다."""
+    try:
+        logger.info("사용 가능한 레이블 목록 조회")
+        
+        async with httpx.AsyncClient() as client:
+            payload = {
+                "jsonrpc": "2.0",
+                "method": "get_loki_labels",
+                "params": {},
+                "id": 1
+            }
+            
+            response = await client.post(
+                f"{MCP_URL}/rpc/v1",
+                json=payload,
+                timeout=10
+            )
+            
+            if response.status_code != 200:
+                logger.error(f"레이블 목록 조회 오류: {response.status_code}")
+                return ["service", "container", "pod", "namespace", "level"]
+            
+            result = response.json()
+            logger.info(f"레이블 목록 응답: {result}")
+            
+            # JSON-RPC 응답 처리
+            if "result" in result:
+                result_data = result["result"]
+                if isinstance(result_data, dict) and "data" in result_data:
+                    data = result_data["data"]
+                    if isinstance(data, dict) and "data" in data:
+                        labels = data["data"]
+                    elif isinstance(data, list):
+                        labels = data
+                    else:
+                        labels = []
+                else:
+                    labels = result_data if isinstance(result_data, list) else []
+                
+                if labels:
+                    logger.info(f"레이블 {len(labels)}개 찾음: {labels}")
+                    return labels
+            
+            logger.warning("레이블을 찾을 수 없어 기본값을 사용합니다")
+            return ["service", "container", "pod", "namespace", "level"]
+    except Exception as e:
+        logger.error(f"레이블 조회 중 오류: {str(e)}")
+        return ["service", "container", "pod", "namespace", "level"]
+
+async def get_label_values(label: str) -> List[str]:
+    """지정된 레이블에 대한 값 목록을 가져옵니다."""
+    try:
+        logger.info(f"레이블 '{label}'에 대한 값 가져오기")
+        
+        # 요청 파라미터 형식 수정
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "list_loki_label_values",
+            "params": {
+                "label": label
+            },
+            "id": 1
+        }
+        
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{MCP_URL}/rpc/v1",
+                json=payload,
+                timeout=10
+            )
+            
+            if response.status_code != 200:
+                logger.error(f"레이블 값 조회 오류: {response.status_code}")
+                if label == "service":
+                    return ["order-service", "payment-service", "user-service", "api-gateway", "frontend", "backend", "database", "cache", "auth"]
+                return []
+            
+            result = response.json()
+            logger.info(f"레이블 값 응답: {result}")
+            
+            # 다양한 응답 형식 처리 개선
+            values = []
+            
+            # 1. 기본 JSON-RPC 응답 구조
+            if "result" in result:
+                result_data = result["result"]
+                
+                # 2. result가 직접 데이터 배열인 경우
+                if isinstance(result_data, list):
+                    values = result_data
+                    logger.info(f"직접 배열 형식 응답: {len(values)} 항목")
+                
+                # 3. result가 객체이고 data 필드가 있는 경우
+                elif isinstance(result_data, dict):
+                    if "data" in result_data:
+                        data = result_data["data"]
+                        
+                        # 3.1 data가 직접 배열인 경우
+                        if isinstance(data, list):
+                            values = data
+                            logger.info(f"data 배열 형식 응답: {len(values)} 항목")
+                        
+                        # 3.2 중첩된 data 구조 (data.data)
+                        elif isinstance(data, dict) and "data" in data:
+                            nested_data = data["data"]
+                            if isinstance(nested_data, list):
+                                values = nested_data
+                                logger.info(f"중첩 data 형식 응답: {len(values)} 항목")
+                
+                # 4. 단순 응답 형식인 경우 (status: success만 있는 경우)
+                elif isinstance(result_data, dict) and "status" in result_data and result_data["status"] == "success":
+                    logger.warning("status:success 형식 응답, 기본값 반환")
+                    if label == "service":
+                        values = ["order-service", "payment-service", "user-service", "api-gateway", "frontend", "backend", "database", "cache", "auth"]
+            
+            # 값이 비어있고 서비스 레이블인 경우 기본값 사용
+            if not values and label == "service":
+                logger.warning("서비스 값을 찾을 수 없어 기본값을 사용합니다.")
+                values = ["order-service", "payment-service", "user-service", "api-gateway", "frontend", "backend", "database", "cache", "auth"]
+                
+            logger.info(f"레이블 '{label}'에 대한 값: {values}")
+            return values
+    except Exception as e:
+        logger.error(f"레이블 값 가져오기 오류: {str(e)}")
+        if label == "service":
+            return ["order-service", "payment-service", "user-service", "api-gateway", "frontend", "backend", "database", "cache", "auth"]
+        return []
+
+async def get_loki_datasource_uid() -> str:
+    """MCP 서버에서 Loki 데이터소스 UID를 가져옵니다."""
+    try:
+        logger.info("Loki 데이터소스 UID 조회 시작")
+        
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "list_datasources",
+            "params": {
+                "type": "loki"
+            },
+            "id": 1
+        }
+        
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{MCP_URL}/rpc/v1",
+                json=payload,
+                timeout=10
+            )
+            
+            if response.status_code != 200:
+                logger.error(f"데이터소스 조회 오류: {response.status_code}")
+                return "loki"
+            
+            result = response.json()
+            logger.info(f"데이터소스 응답: {result}")
+            
+            # JSON-RPC 응답 처리
+            if "result" in result:
+                datasources = result["result"]
+                for ds in datasources:
+                    if isinstance(ds, dict) and ds.get("type") == "loki":
+                        uid = ds.get("uid")
+                        if uid:
+                            logger.info(f"Loki 데이터소스 UID 찾음: {uid}")
+                            return uid
+            
+        logger.warning("Loki 데이터소스를 찾을 수 없어 기본값 사용")
+        return "loki"
+    except Exception as e:
+        logger.error(f"데이터소스 UID 조회 중 오류: {str(e)}")
+        return "loki"
+
+# == MCP-Grafana 서버에 로그 쿼리 요청 ==
+async def query_logs(
+    service_name: str, 
+    time_range: Optional[Tuple[datetime, datetime]] = None,
+    query_filter: Optional[str] = None,
+    state: Optional[LogAnalysisState] = None
+) -> List[Dict[str, Any]]:
+    """Loki에서 로그를 쿼리합니다."""
+    try:
+        # 기본 시간 범위: 현재 시간에서 1시간 전까지
+        if not time_range:
+            end_time = datetime.now(timezone.utc)
+            start_time = end_time - timedelta(hours=1)
+        else:
+            start_time, end_time = time_range
+        
+        # 타임스탬프를 문자열 형식으로 변환 (ISO 8601)
+        start_ts_str = start_time.isoformat()
+        end_ts_str = end_time.isoformat()
+        
+        # 로그 쿼리 로직
+        logger.info(f"로그 쿼리 시작: 서비스={service_name}, 시작={start_time}, 종료={end_time}")
+        
+        # LLM을 사용하여 LogQL 쿼리 생성 (if state is provided)
+        if state:
+            try:
+                log_query = await generate_logql_query_with_llm(state)
+            except Exception as e:
+                logger.error(f"LogQL 쿼리 생성 중 오류: {str(e)}")
+                # 기본 쿼리 생성
+                log_query = f'{{service="{service_name}"}}'
+        else:
+            # 기본 로그 쿼리를 구성합니다
+            log_query = f'{{service="{service_name}"}}'
+            
+            # 추가 필터가 있으면 필터 연산자 수정
+            if query_filter:
+                log_query = f'{log_query} |= "{query_filter}"'
+        
+        logger.info(f"로그 쿼리: {log_query}")
+        
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "query_loki",
+            "params": {
+                "query": log_query,
+                "start": start_ts_str,
+                "end": end_ts_str,
+                "limit": 100
+            },
+            "id": 1
+        }
+        
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{MCP_URL}/rpc/v1",
+                json=payload,
+                timeout=15
+            )
+            
+            if response.status_code != 200:
+                logger.error(f"로그 쿼리 오류: {response.status_code}")
+                return []
+            
+            result = response.json()
+            logger.debug(f"로그 쿼리 응답: {result}")
+            
+            # JSON-RPC 응답 처리 로직 개선
+            log_entries = []
+            
+            if "result" in result:
+                result_data = result["result"]
+                
+                # 직접 data 배열을 가진 경우 (신규 API 응답 형식)
+                if isinstance(result_data, dict) and "data" in result_data:
+                    data = result_data["data"]
+                    if isinstance(data, list):
+                        # 응답이 이미 로그 항목 리스트인 경우
+                        log_entries = data
+                        logger.info(f"직접 로그 항목 {len(log_entries)}개 발견")
+                    elif isinstance(data, dict) and "data" in data:
+                        # 중첩된 data 구조 처리
+                        nested_data = data["data"]
+                        if isinstance(nested_data, list):
+                            log_entries = nested_data
+                            logger.info(f"중첩된 로그 항목 {len(log_entries)}개 발견")
+            
+            if log_entries:
+                logger.info(f"로그 항목 {len(log_entries)}개 반환")
+                return log_entries
+            else:
+                logger.warning("로그를 찾을 수 없습니다")
+                return []
+    except Exception as e:
+        logger.error(f"로그 쿼리 중 오류: {str(e)}")
+        logger.error(traceback.format_exc())
+        return []
+
+def build_logql_query(
+    service: Optional[str] = None,
+    trace_id: Optional[str] = None,
+    filters: Optional[Dict[str, Any]] = None
+) -> Optional[str]:
+    """
+    LogQL 쿼리를 구성합니다.
+    
+    매개변수:
+        service: 쿼리할 서비스 이름 (선택적)
+        trace_id: 트레이스 ID (선택적)
+        filters: 추가 필터 조건 (선택적)
+        
+    반환값:
+        구성된 LogQL 쿼리 문자열 또는 None (구성 실패 시)
+    """
+    # 필터 조건 초기화
+    filter_conditions = []
+    
+    # 서비스 이름으로 필터링
+    if service:
+        filter_conditions.append(f'service="{service}"')
+    
+    # 추가 필터 처리
+    if filters:
+        # 레벨 필터
+        if 'level' in filters and filters['level']:
+            filter_conditions.append(f'level="{filters["level"]}"')
+        
+        # 사용자 정의 라벨 필터
+        if 'labels' in filters and isinstance(filters['labels'], dict):
+            for key, value in filters['labels'].items():
+                if key and value:
+                    filter_conditions.append(f'{key}="{value}"')
+    
+    # 필터 조건이 없는 경우
+    if not filter_conditions:
+        # 서비스와 트레이스 ID가 모두 없는 경우, 기본 필터 사용
+        filter_conditions.append('{}')
+    
+    # 라벨 셀렉터 구성
+    label_selector = '{' + ', '.join(filter_conditions) + '}'
+    
+    # 라인 필터 구성
+    line_filters = []
+    
+    # 트레이스 ID로 필터링
+    if trace_id:
+        line_filters.append(f'|~ "trace_id.*{trace_id}"')
+    
+    # 텍스트 검색 필터
+    if filters and 'message' in filters and filters['message']:
+        message_filter = filters['message'].replace('"', '\\"')
+        line_filters.append(f'|~ "{message_filter}"')
+    
+    # 최종 쿼리 구성
+    query = label_selector
+    if line_filters:
+        query += ' '.join(line_filters)
+    
+    return query
+
+def to_rfc3339(timestamp_ns: int) -> str:
+    """
+    나노초 타임스탬프를 RFC3339 형식 문자열로 변환합니다.
+    
+    매개변수:
+        timestamp_ns: 나노초 단위 타임스탬프
+        
+    반환값:
+        RFC3339 형식 문자열
+    """
+    seconds = timestamp_ns / 1e9
+    dt = datetime.utcfromtimestamp(seconds)
+    microseconds = int((timestamp_ns % 1e9) / 1e3)
+    dt = dt.replace(microsecond=microseconds)
+    return dt.isoformat("T") + "Z"
+
+def parse_time_range(time_range: str) -> int:
+    """
+    문자열 형식의 시간 범위를 초 단위로 변환합니다.
+    
+    매개변수:
+        time_range: 시간 범위 문자열 (예: "1h", "3h", "1d")
+        
+    반환값:
+        경과 시간(초)
+    """
+    now = time.time()
+    
+    # '3h'와 같은 간단한 형식 처리
+    simple_match = re.match(r'(\d+)([hmd])', time_range, re.IGNORECASE)
+    if simple_match:
+        value = int(simple_match.group(1))
+        unit = simple_match.group(2).lower()
+        if unit == 'h':
+            seconds = value * 3600
+        elif unit == 'm':
+            seconds = value * 60
+        elif unit == 'd':
+            seconds = value * 86400
+        else:
+            seconds = 3600  # 기본값: 1시간
+        return seconds
+    
+    # "last Xh/m/d" 형식 처리
+    last_match = re.match(r'last\s+(\d+)([hmd])', time_range, re.IGNORECASE)
+    if last_match:
+        value = int(last_match.group(1))
+        unit = last_match.group(2).lower()
+        if unit == 'h':
+            seconds = value * 3600
+        elif unit == 'm':
+            seconds = value * 60
+        elif unit == 'd':
+            seconds = value * 86400
+        else:
+            seconds = 3600
+        return seconds
+    
+    # "now-Xh/m/d" 형식 처리
+    now_match = re.match(r'now-(\d+)([hmd])', time_range, re.IGNORECASE)
+    if now_match:
+        value = int(now_match.group(1))
+        unit = now_match.group(2).lower()
+        if unit == 'h':
+            seconds = value * 3600
+        elif unit == 'm':
+            seconds = value * 60
+        elif unit == 'd':
+            seconds = value * 86400
+        else:
+            seconds = 3600
+        return seconds
+    
+    # 한국어 표현 처리 (예: "3시간", "10분", "2일")
+    kr_match = re.match(r'(\d+)(시간|분|일)', time_range)
+    if kr_match:
+        value = int(kr_match.group(1))
+        unit = kr_match.group(2)
+        if unit == '시간':
+            seconds = value * 3600
+        elif unit == '분':
+            seconds = value * 60
+        elif unit == '일':
+            seconds = value * 86400
+        else:
+            seconds = 3600
+        return seconds
+    
+    # 기본값: 1시간 (3600초)
+    return 3600
+
+async def query_traces(
+    service_name: str,
+    time_range: Optional[Tuple[datetime, datetime]] = None,
+    operation_name: Optional[str] = None,
+    trace_duration_min: Optional[float] = None,
+    limit: int = 20
+) -> List[Dict[str, Any]]:
+    """Tempo에서 트레이스를 쿼리합니다."""
+    try:
+        # 기본 시간 범위: 현재 시간에서 1시간 전까지
+        if not time_range:
+            end_time = datetime.now(timezone.utc)
+            start_time = end_time - timedelta(hours=1)
+        else:
+            start_time, end_time = time_range
+        
+        # 타임스탬프를 문자열 형식으로 변환 (ISO 8601)
+        start_ts_str = start_time.isoformat()
+        end_ts_str = end_time.isoformat()
+        
+        logger.info(f"트레이스 쿼리 시작: 서비스={service_name}, 시작={start_time}, 종료={end_time}")
+
+        # 검색 조건 설정
+        search_params = {
+            "service": service_name,
+            "start": start_ts_str,
+            "end": end_ts_str,
+            "limit": limit
+        }
+
+        # 선택적 파라미터 추가
+        if operation_name:
+            search_params["operation"] = operation_name
+        
+        if trace_duration_min is not None:
+            search_params["minDuration"] = f"{int(trace_duration_min * 1000000)}ns"
+        
+        # JSON-RPC 요청 구성
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "query_tempo",
+            "params": search_params,
+            "id": 1
+        }
+        
+        logger.info(f"트레이스 쿼리 요청: {search_params}")
+        
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{TEMPO_MCP_URL}/rpc/v1",
+                json=payload,
+                timeout=15
+            )
+            
+            if response.status_code != 200:
+                logger.error(f"트레이스 쿼리 오류: {response.status_code}")
+                return []
+            
+            result = response.json()
+            logger.info(f"트레이스 쿼리 응답: {result}")
+            
+            # JSON-RPC 응답 처리
+            if "result" in result:
+                result_data = result["result"]
+                # result_data가 딕셔너리이고 "traces" 필드가 있는 경우 (원래 예상 형식)
+                if isinstance(result_data, dict) and "traces" in result_data:
+                    traces = result_data["traces"]
+                    logger.info(f"트레이스 {len(traces)}개 반환")
+                    return traces
+                # result_data가 직접 리스트인 경우 (현재 실제 응답 형식)
+                elif isinstance(result_data, list):
+                    logger.info(f"트레이스 {len(result_data)}개 반환")
+                    return result_data
+            
+            logger.warning("트레이스를 찾을 수 없습니다")
+            return []
+    except Exception as e:
+        logger.error(f"트레이스 쿼리 중 오류: {str(e)}")
+        return []
+
+async def async_query_logs(state: LogAnalysisState) -> LogAnalysisState:
+    """LogAnalysisState에서 파라미터를 추출하여 로그 쿼리를 실행합니다."""
+    # 파라미터 추출
+    params = state.get("parameters", {})
+    service = params.get("service")
+    
+    if not service:
+        logger.error("로그 쿼리에 서비스 지정이 필요합니다")
+        state["log_data"] = None
+        return state
+    
+    # 시간 범위 처리
+    time_range = params.get("timeRange", "1h")
+    time_range_value = 60  # 기본값: 60분 (1시간)
+    
+    if isinstance(time_range, str):
+        if time_range.endswith("m"):
+            time_range_value = int(time_range[:-1])
+        elif time_range.endswith("h"):
+            time_range_value = int(time_range[:-1]) * 60  # 시간을 분으로 변환
+        elif time_range.endswith("d"):
+            time_range_value = int(time_range[:-1]) * 60 * 24  # 일을 분으로 변환
+    
+    # 시간 범위 계산
+    end_time = datetime.now(timezone.utc)
+    start_time = end_time - timedelta(minutes=time_range_value)
+    
+    # LLM 기반 쿼리로 직접 로그 조회
+    result = await query_logs(
+        service_name=service,
+        time_range=(start_time, end_time),
+        state=state  # 전체 상태 전달하여 LLM 쿼리 생성
+    )
+    
+    if result:
+        logger.info(f"{len(result)}개의 로그 항목을 찾았습니다")
+        state["log_data"] = result
+        
+        # 로그에서 트레이스 ID 추출
+        trace_ids = extract_trace_ids_from_logs(result)
+        if trace_ids:
+            state["extracted_trace_ids"] = trace_ids
+            logger.info(f"로그에서 {len(trace_ids)}개의 트레이스 ID를 추출했습니다: {trace_ids[:5]}")
+    else:
+        logger.warning("로그를 찾을 수 없습니다")
+        state["log_data"] = []
+    
+    return state
+
+def extract_trace_ids_from_logs(logs: List[Dict[str, Any]]) -> List[str]:
+    """로그에서 트레이스 ID를 추출합니다."""
+    trace_ids = set()
+    
+    # 정규 표현식 패턴
+    # 1. trace_id=HEXSTRING 또는 traceID=HEXSTRING 패턴
+    # 2. "traceId":"HEXSTRING" 또는 "trace_id":"HEXSTRING" JSON 패턴
+    # 3. 단독 32/64자 16진수 문자열
+    patterns = [
+        re.compile(r'trace[_-]?id\s*[=:]\s*["\']?([0-9a-f]{16,64})["\']?', re.IGNORECASE),
+        re.compile(r'["\']trace[_-]?id["\']\s*:\s*["\']([0-9a-f]{16,64})["\']', re.IGNORECASE),
+        re.compile(r'(?<![0-9a-f])([0-9a-f]{32}|[0-9a-f]{64})(?![0-9a-f])')
+    ]
+    
+    for log in logs:
+        message = log.get("line", log.get("message", ""))
+        
+        for pattern in patterns:
+            matches = pattern.findall(message)
+            for match in matches:
+                # 유효한 트레이스 ID인지 검증
+                if all(c in "0123456789abcdef" for c in match.lower()):
+                    trace_ids.add(match)
+    
+    return list(trace_ids)
+
+async def async_query_traces(state: LogAnalysisState) -> LogAnalysisState:
+    """트레이스 쿼리를 실행합니다."""
+    params = state.get("parameters", {})
+    service = params.get("service", "order-service")
+    
+    # 시간 범위 처리
+    time_range = params.get("timeRange", "1h")
+    seconds = parse_time_range(time_range)
+    end_time = datetime.now()
+    start_time = end_time - timedelta(seconds=seconds)
+    
+    # 로그 데이터 확인
+    log_data = state.get("log_data", [])
+    
+    # 트레이스 ID 추출
+    trace_ids = set()
+    
+    # 1. 로그에서 트레이스 ID 추출
+    if log_data:
+        extracted_ids = extract_trace_ids_from_logs(log_data)
+        trace_ids.update(extracted_ids)
+        logger.info(f"로그에서 {len(extracted_ids)}개의 트레이스 ID를 추출했습니다: {extracted_ids}")
+    
+    # 2. 파라미터에서 직접 트레이스 ID 체크
+    if params.get("trace_id"):
+        trace_ids.add(params.get("trace_id"))
+        logger.info(f"파라미터에서 트레이스 ID 추출: {params.get('trace_id')}")
+    
+    traces = []
+    
+    # 트레이스 ID가 있으면 해당 ID로 쿼리
+    if trace_ids:
+        for trace_id in trace_ids:
+            logger.info(f"트레이스 ID로 쿼리: {trace_id}")
+            trace_result = await query_trace_by_id(trace_id)
+            if trace_result:
+                traces.extend(trace_result)
+    
+    # 트레이스 ID가 없거나 결과가 없으면 서비스 기반 쿼리
+    if not traces:
+        logger.info(f"서비스 기반 트레이스 쿼리: {service}, 시작={start_time}, 종료={end_time}")
+        try:
+            additional_params = {
+                "limit": 10
+            }
+            
+            # 오류 필터
+            if params.get("errors") or params.get("error") or params.get("show_errors"):
+                additional_params["error_traces"] = True
+            
+            # 최소/최대 지속 시간
+            for param_name, api_param in [("min_duration", "min_duration"), ("max_duration", "max_duration")]:
+                if params.get(param_name):
+                    additional_params[api_param] = params.get(param_name)
+            
+            trace_result = await query_traces(
+                service_name=service,
+                time_range=(start_time, end_time),
+                operation_name=params.get("operation"),
+                **additional_params
+            )
+            traces.extend(trace_result)
+        except Exception as e:
+            logger.error(f"트레이스 쿼리 실행 중 오류: {str(e)}")
+    
+    # 트레이스가 여전히 없으면 샘플 데이터 생성 고려
+    if not traces and log_data:
+        logger.warning("실제 트레이스를 찾을 수 없어 로그 기반 샘플 트레이스 생성을 시도합니다")
+        # 로그 데이터에서 서비스 및 작업 정보 추출하여 트레이스 생성
+        traces = generate_sample_traces_from_logs(log_data, service)
+    
+    logger.info(f"{len(traces)}개의 트레이스를 찾았습니다")
+    state["trace_data"] = traces
+    return state
+
+def generate_sample_traces_from_logs(logs: List[Dict[str, Any]], default_service: str) -> List[Dict[str, Any]]:
+    """로그 데이터를 기반으로 샘플 트레이스 데이터를 생성합니다."""
+    logger.info(f"{len(logs)}개의 로그 항목으로부터 샘플 트레이스 생성")
+    
+    # 로그에서 서비스 및 엔드포인트 패턴 추출
+    service_pattern = re.compile(r'service[=:][\'"]([\w-]+)[\'"]', re.IGNORECASE)
+    endpoint_pattern = re.compile(r'(GET|POST|PUT|DELETE|PATCH)\s+(\/[\w\/\-{}]+)', re.IGNORECASE)
+    error_pattern = re.compile(r'(error|exception|fail|failed|timeout)', re.IGNORECASE)
+    
+    traces = []
+    processed_logs = 0
+    
+    # 로그 그룹화 (시간적으로 가까운 로그는 같은 트레이스일 가능성이 높음)
+    log_groups = []
+    current_group = []
+    last_timestamp = None
+    
+    # 로그 시간순 정렬
+    sorted_logs = sorted(logs, key=lambda x: x.get("timestamp", ""))
+    
+    for log in sorted_logs:
+        timestamp = log.get("timestamp", "")
+        if not timestamp:
+            continue
+            
+        # 새 그룹 시작 조건: 첫 로그이거나 이전 로그와 시간 차이가 1초 이상
+        if not last_timestamp or not current_group:
+            current_group = [log]
+            last_timestamp = timestamp
+        else:
+            # 시간 차이 계산 (간단한 문자열 비교로 대체)
+            time_diff = abs(timestamp.replace(last_timestamp, ""))
+            if time_diff > "1":  # 1초 이상 차이
+                if current_group:
+                    log_groups.append(current_group)
+                current_group = [log]
+            else:
+                current_group.append(log)
+            last_timestamp = timestamp
+    
+    # 마지막 그룹 추가
+    if current_group:
+        log_groups.append(current_group)
+    
+    # 각 로그 그룹에서 트레이스 생성
+    for group_idx, log_group in enumerate(log_groups):
+        if not log_group:
+            continue
+            
+        # 첫 로그에서 정보 추출
+        first_log = log_group[0]
+        message = first_log.get("line", first_log.get("message", ""))
+        
+        # 서비스명 추출, 없으면 기본값 사용
+        service_match = service_pattern.search(message)
+        span_service = service_match.group(1) if service_match else default_service
+        
+        # 엔드포인트 추출, 없으면 기본값 사용
+        span_endpoint_match = endpoint_pattern.search(message)
+        span_operation = span_endpoint_match.group(2) if span_endpoint_match else f"/api/unknown/{group_idx}"
+        
+        # 오류 여부 확인
+        has_error = any(error_pattern.search(log.get("line", log.get("message", ""))) for log in log_group)
+        
+        # 임의의 트레이스 ID 생성 (로그 내용 기반 해시)
+        trace_id_base = hashlib.md5((message + span_service + span_operation).encode()).hexdigest()
+        
+        # 스팬 생성
+        spans = []
+        span_count = min(len(log_group), 5)  # 최대 5개 스팬
+        
+        for i in range(span_count):
+            log = log_group[min(i, len(log_group)-1)]
+            log_message = log.get("line", log.get("message", ""))
+            
+            # 스팬별 서비스 및 작업 추출
+            span_service_match = service_pattern.search(log_message)
+            span_service = span_service_match.group(1) if span_service_match else span_service
+            
+            span_endpoint_match = endpoint_pattern.search(log_message)
+            span_operation = span_endpoint_match.group(2) if span_endpoint_match else span_operation
+            
+            # 스팬 오류 여부
+            span_has_error = error_pattern.search(log_message) is not None
+            
+            # 임의의 스팬 ID 생성
+            span_id = trace_id_base[i*2:i*2+16] if len(trace_id_base) >= (i*2+16) else f"{i}{'0'*15}"
+            
+            # 스팬 생성
+            span = {
+                "spanID": span_id,
+                "service": span_service,
+                "operation": span_operation,
+                "startTime": log.get("timestamp", ""),
+                "durationMs": 10 + (i * 50),  # 임의의 지속 시간
+                "status": "error" if span_has_error else "ok",
+                "logMessage": log_message[:100] + "..." if len(log_message) > 100 else log_message
+            }
+            
+            # 부모 스팬 설정
+            if i > 0:
+                span["parentSpanID"] = spans[i-1]["spanID"]
+            
+            spans.append(span)
+        
+        # 트레이스 생성
+        if spans:
+            trace = {
+                "traceID": trace_id_base,
+                "rootService": span_service,
+                "rootOperation": span_operation,
+                "startTime": first_log.get("timestamp", ""),
+                "durationMs": sum(span.get("durationMs", 0) for span in spans),
+                "spanCount": len(spans),
+                "errorCount": 1 if has_error else 0,
+                "spans": spans,
+                "isSynthetic": True  # 이것이 합성된 트레이스임을 표시
+            }
+            traces.append(trace)
+        
+        processed_logs += len(log_group)
+    
+    logger.info(f"로그 데이터로부터 {len(traces)}개의 샘플 트레이스를 생성했습니다 ({processed_logs}/{len(logs)} 로그 처리)")
+    return traces
+
+async def detect_intent_with_llm(state: LogAnalysisState) -> LogAnalysisState:
+    """
+    LLM을 사용하여 사용자 쿼리에서 의도를 감지합니다.
+    """
+    user_query = state["user_query"]["text"]
+    logger.info(f"LLM 의도 감지: 사용자 쿼리 = {user_query}")
+    
+    # 시스템 프롬프트 구성
+    system_prompt = """당신은 로그 및 트레이스 분석 시스템의 일부입니다. 
+사용자 쿼리를 분석하여 의도를 파악하세요.
+가능한 의도는 다음과 같습니다:
+1. LOG_QUERY: 로그 조회
+2. TRACE_QUERY: 트레이스 조회
+3. STATUS_QUERY: 서비스 상태 조회
+
+사용자 쿼리를 분석하여 모든 관련 의도를 JSON 형식으로 반환하세요. 예:
+{"intents": ["LOG_QUERY"]}
+{"intents": ["TRACE_QUERY"]}
+{"intents": ["STATUS_QUERY"]}
+{"intents": ["LOG_QUERY", "TRACE_QUERY"]} <- 여러 의도를 가진 경우
+
+의도 선택 기준:
+- LOG_QUERY: 로그, 에러, 경고, 메시지, 출력 등 로그 관련 단어가 있을 때
+- TRACE_QUERY: 트레이스, 호출, 요청, 추적, 스팬 등 트레이스 관련 단어가 있을 때
+- STATUS_QUERY: 상태, 헬스, 실행 중, 살아있는지 등 상태 관련 단어가 있을 때
+
+관련된 모든 의도를 포함하세요. 사용자가 로그와 트레이스를 모두 요청한 경우, ["LOG_QUERY", "TRACE_QUERY"]와 같이 반환하세요."""
+
+    # LLM 호출
+    try:
+        messages = [
+            SystemMessage(content=system_prompt),
+            HumanMessage(content=user_query)
+        ]
+        
+        response = await llm.ainvoke(messages)
+        logger.info(f"LLM 응답: {response.content}")
+        
+        # JSON 형식 응답 파싱
+        try:
+            intent_data = json.loads(response.content)
+            
+            # 복수 의도 처리
+            if "intents" in intent_data and isinstance(intent_data["intents"], list) and intent_data["intents"]:
+                state["detected_intents"] = intent_data["intents"]
+                # 호환성을 위해 첫 번째 의도를 detected_intent로 설정
+                state["detected_intent"] = intent_data["intents"][0]
+                logger.info(f"LLM이 감지한 의도들: {intent_data['intents']}")
+            # 단일 의도 처리 (이전 형식 지원)
+            elif "intent" in intent_data:
+                intent = intent_data.get("intent", "LOG_QUERY")
+                state["detected_intent"] = intent
+                state["detected_intents"] = [intent]
+                logger.info(f"LLM이 감지한 의도: {intent}")
+            else:
+                # 기본값
+                state["detected_intent"] = "LOG_QUERY"
+                state["detected_intents"] = ["LOG_QUERY"]
+                logger.info("의도를 찾을 수 없어 기본값(LOG_QUERY) 사용")
+        except json.JSONDecodeError:
+            # JSON 파싱 오류 시 텍스트에서 의도 추출 시도
+            content = response.content.lower()
+            detected_intents = []
+            
+            if "log_query" in content:
+                detected_intents.append("LOG_QUERY")
+            if "trace_query" in content:
+                detected_intents.append("TRACE_QUERY")
+            if "status_query" in content:
+                detected_intents.append("STATUS_QUERY")
+                
+            if not detected_intents:
+                detected_intents = ["LOG_QUERY"]  # 기본값
+                
+            state["detected_intents"] = detected_intents
+            state["detected_intent"] = detected_intents[0]  # 첫 번째 의도를 주요 의도로 설정
+            
+            logger.info(f"텍스트에서 추출한 의도들: {detected_intents}")
+    except Exception as e:
+        logger.error(f"LLM 의도 감지 중 오류 발생: {str(e)}")
+        # 오류 발생 시 기존 키워드 기반 방식으로 폴백
+        state = await detect_intent(state)
+        # 호환성을 위해 detected_intents 추가
+        if "detected_intent" in state and "detected_intents" not in state:
+            state["detected_intents"] = [state["detected_intent"]]
+    
+    return state
+
+async def extract_parameters_with_llm(state: LogAnalysisState) -> LogAnalysisState:
+    """LLM을 사용하여 사용자 쿼리에서 매개변수를 추출합니다."""
+    intent = state["detected_intent"]
+    user_query = state["user_query"]["text"]
+    logger.info(f"LLM 매개변수 추출: 의도 = {intent}, 쿼리 = {user_query}")
+    
+    # 이용 가능한 서비스 목록 가져오기
+    available_services = await get_label_values("service")
+    available_services_str = ", ".join(available_services) if available_services else "order-service, payment-service, user-service, api-gateway"
+    
+    # 이용 가능한 레이블 목록 가져오기
+    available_labels = await get_available_labels()
+    available_labels_str = ", ".join(available_labels) if available_labels else "service, container, pod, namespace, level"
+    
+    # 시스템 프롬프트 구성
+    system_prompt = f"""당신은 로그 및 트레이스 분석 시스템의 일부입니다.
+사용자 쿼리에서 다음 매개변수를 추출하세요:
+
+1. service: 서비스 이름 (필수)
+   - 사용 가능한 서비스: {available_services_str}
+   - 언급되지 않은 경우 "order-service" 사용
+
+2. timeRange: 조회 시간 범위 (선택)
+   - 예: "10m", "1h", "2d", "3h" 형식 (분/시간/일)
+   - 언급되지 않은 경우 "1h" 사용
+
+3. level: 로그 레벨 (로그 쿼리일 경우, 선택)
+   - error, warn, info, debug 중 하나
+   - 언급되지 않은 경우 모든 레벨 포함 (null 반환)
+
+4. additionalFilters: 위에 없는 기타 필터 (선택)
+   - 사용 가능한 레이블: {available_labels_str}
+
+추출한 매개변수를 JSON 형식으로 반환하세요. 코드 블록 없이 순수 JSON만 반환하세요. 예:
+{{
+  "service": "order-service",
+  "timeRange": "3h",
+  "level": null,
+  "additionalFilters": {{}}
+}}
+
+현재 의도: {intent}
+한글로 된 시간 표현(예: "3시간", "10분")도 적절하게 변환하세요."""
+
+    # LLM 호출
+    try:
+        messages = [
+            SystemMessage(content=system_prompt),
+            HumanMessage(content=user_query)
+        ]
+        
+        response = await llm.ainvoke(messages)
+        logger.info(f"LLM 파라미터 추출 응답: {response.content}")
+        
+        # JSON 형식 응답 파싱
+        try:
+            # 코드 블록 제거
+            content = response.content.strip()
+            if content.startswith("```json"):
+                content = content[7:]
+            if content.endswith("```"):
+                content = content[:-3]
+            content = content.strip()
+            
+            params = json.loads(content)
+            logger.info(f"LLM이 추출한 매개변수: {params}")
+            
+            # 최소한 서비스 확인
+            if not params.get("service"):
+                # 서비스가 없으면 기본값 사용
+                params["service"] = "order-service"
+                logger.info(f"서비스 누락, 기본값 사용: {params['service']}")
+            
+            # timeRange 확인
+            if not params.get("timeRange"):
+                params["timeRange"] = "1h"
+                logger.info(f"시간 범위 누락, 기본값 사용: {params['timeRange']}")
+            
+            state["parameters"] = params
+            
+        except json.JSONDecodeError as e:
+            logger.error(f"LLM 응답 JSON 파싱 오류: {e}")
+            logger.error(f"파싱 실패한 응답: {response.content}")
+            # 파싱 오류 시 기존 방식으로 폴백
+            state = await extract_parameters(state)
+    except Exception as e:
+        logger.error(f"LLM 매개변수 추출 중 오류 발생: {str(e)}")
+        # 오류 발생 시 기존 방식으로 폴백
+        state = await extract_parameters(state)
+    
+    return state
+
+async def generate_logql_query_with_llm(state: LogAnalysisState) -> str:
+    """LLM을 사용하여 LogQL 쿼리를 생성합니다."""
+    params = state.get("parameters", {})
+    service = params.get("service", "order-service")
+    level = params.get("level")
+    
+    # 시스템 프롬프트 구성
+    system_prompt = """당신은 LogQL 쿼리 생성 전문가입니다.
+제공된 매개변수를 기반으로 유효한 LogQL 쿼리를 생성하세요.
+
+LogQL 쿼리 형식:
+- 레이블 필터: {label="value", label2="value2"}
+- 라인 필터: |= "포함할 텍스트" 또는 |~ "정규식 패턴"
+
+로그 레벨 필터링:
+- level="error" 또는 level=~"error|warn"
+
+올바른 LogQL 형식을 준수하고, 이스케이프가 필요한 문자는 적절히 처리하세요.
+최종 쿼리만 반환하세요. 설명이나 추가 텍스트 없이."""
+
+    service_escaped = service.replace('"', '\\"')
+    query_components = [f'service="{service_escaped}"']
+    
+    # 레벨 필터
+    if level:
+        level_escaped = level.replace('"', '\\"')
+        query_components.append(f'level="{level_escaped}"')
+    
+    # 기타 필터
+    additional_filters = params.get("additionalFilters", {})
+    for key, value in additional_filters.items():
+        if key not in ["service", "level", "timeRange"] and value:
+            key_escaped = key.replace('"', '\\"')
+            value_escaped = str(value).replace('"', '\\"')
+            query_components.append(f'{key_escaped}="{value_escaped}"')
+    
+    # 기본 쿼리 생성
+    basic_query = "{" + ", ".join(query_components) + "}"
+    
+    # 쿼리가 복잡한 경우에만 LLM 사용
+    if len(query_components) > 2 or level is None:
+        try:
+            messages = [
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=f"""매개변수:
+- 서비스: {service}
+- 로그 레벨: {level if level else "모든 레벨"}
+- 추가 필터: {str({k:v for k,v in additional_filters.items() if k not in ["service", "level", "timeRange"]})}
+
+기본 생성된 쿼리: {basic_query}
+이 쿼리를 개선하거나 그대로 사용해도 됩니다.""")
+            ]
+            
+            response = await llm.ainvoke(messages)
+            generated_query = response.content.strip()
+            
+            # LogQL 쿼리 형식 검증
+            if generated_query.startswith("{") and "}" in generated_query:
+                logger.info(f"LLM 생성 LogQL: {generated_query}")
+                return generated_query
+            else:
+                logger.warning(f"LLM이 생성한 쿼리가 유효하지 않음: {generated_query}")
+                return basic_query
+        except Exception as e:
+            logger.error(f"LogQL 생성 중 오류: {str(e)}")
+            return basic_query
+    else:
+        return basic_query
+
+async def run_workflow(query: str) -> Dict[str, Any]:
+    """사용자 쿼리 처리를 위한 워크플로우를 실행합니다."""
+    # 초기 상태 생성
+    state = LogAnalysisState({
+        "query": query,
+        "user_query": {"text": query},
+        "detected_intent": None,
+        "detected_intents": [],
+        "parameters": {},
+        "log_data": None,
+        "trace_data": None
+    })
+    
+    # LLM 기반 의도 감지
+    state = await detect_intent_with_llm(state)
+    
+    # LLM 기반 파라미터 추출
+    state = await extract_parameters_with_llm(state)
+    
+    # 의도에 따라 적절한 쿼리 실행
+    intents = state.get("detected_intents", [state.get("detected_intent")])
+    
+    # 로그 쿼리 실행 (LOG_QUERY 의도 포함 시)
+    if "LOG_QUERY" in intents:
+        state = await async_query_logs(state)
+    
+    # 트레이스 쿼리 실행 (TRACE_QUERY 의도 포함 시)
+    if "TRACE_QUERY" in intents:
+        state = await async_query_traces(state)
+    
+    # LLM을 사용하여 결과 요약
+    state = await summarize_results_with_llm(state)
+    
+    primary_intent = state.get("detected_intent", "LOG_QUERY")
+    logger.info(f"분석 완료: {primary_intent}")
+    
+    # 응답 구성
+    response = {
+        "intent": primary_intent,
+        "intents": intents,
+        "parameters": state.get("parameters", {}),
+        "log_data": state.get("log_data"),
+        "trace_data": state.get("trace_data"),
+        "summary": state.get("summary")  # 요약 정보 추가
+    }
+    
+    return response
+
+@app.post("/analyze")
+async def analyze_query(query: UserQuery):
+    """사용자 쿼리를 분석하고 결과를 반환합니다."""
+    logger.info(f"분석 쿼리 수신: {query.query}")
+    
+    try:
+        result = await run_workflow(query.query)
+        logger.info(f"분석 완료: {result['intent']}")
+        return QueryResponse(
+            response=result,
+            context=query.context or {}
+        )
+    except Exception as e:
+        logger.exception("쿼리 분석 중 오류 발생")
+        raise HTTPException(
+            status_code=500,
+            detail=f"쿼리 처리 오류: {str(e)}"
+        )
+
+# API 엔드포인트 추가
+@app.get("/health")
+async def health_check():
+    """
+    서버 상태 확인을 위한 헬스 체크 엔드포인트
+    """
+    return {
+        "status": "ok",
+        "version": "1.0.0",
+        "timestamp": datetime.now().isoformat()
+    }
+
+@app.get("/services")
+async def get_services():
+    """
+    사용 가능한 서비스 목록을 반환합니다
+    """
+    try:
+        # 서비스 레이블 값 조회
+        services = await get_label_values("service")
+        return {
+            "status": "success",
+            "services": services
+        }
+    except Exception as e:
+        logger.exception("서비스 목록 조회 중 오류")
+        return {
+            "status": "error",
+            "error": str(e)
+        }
+
+@app.get("/network-debug")
+async def network_debug():
+    """
+    네트워크 연결 상태를 확인하는 디버그 엔드포인트
+    """
+    try:
+        # 각 서비스로의 연결 테스트
+        results = {}
+        
+        # MCP API 연결 테스트
+        async with httpx.AsyncClient() as client:
+            try:
+                # DNS 확인 테스트
+                import socket
+                try:
+                    grafana_mcp_ip = socket.gethostbyname("grafana-mcp")
+                    results["grafana_mcp_dns"] = {"status": "success", "ip": grafana_mcp_ip}
+                except socket.gaierror as e:
+                    results["grafana_mcp_dns"] = {"status": "error", "error": str(e)}
+                
+                try:
+                    tempo_mcp_ip = socket.gethostbyname("tempo-mcp")
+                    results["tempo_mcp_dns"] = {"status": "success", "ip": tempo_mcp_ip}
+                except socket.gaierror as e:
+                    results["tempo_mcp_dns"] = {"status": "error", "error": str(e)}
+                
+                # MCP API 연결 테스트
+                response = await client.get(f"{MCP_API_URL}/health", timeout=5)
+                results["mcp_api"] = {
+                    "status": "success" if response.status_code == 200 else "error",
+                    "status_code": response.status_code,
+                    "response": response.text[:100] if response.status_code == 200 else None
+                }
+            except Exception as e:
+                results["mcp_api"] = {"status": "error", "error": str(e)}
+            
+            # Tempo API 연결 테스트
+            try:
+                response = await client.get(f"{TEMPO_RPC_URL}/health", timeout=5)
+                results["tempo_api"] = {
+                    "status": "success" if response.status_code == 200 else "error",
+                    "status_code": response.status_code,
+                    "response": response.text[:100] if response.status_code == 200 else None
+                }
+            except Exception as e:
+                results["tempo_api"] = {"status": "error", "error": str(e)}
+            
+            # 환경 변수 정보
+            results["env_vars"] = {
+                "MCP_API_URL": MCP_API_URL,
+                "TEMPO_RPC_URL": TEMPO_RPC_URL,
+                "MCP_URL": MCP_URL,
+                "TEMPO_MCP_URL": TEMPO_MCP_URL
+            }
+        
+        return {
+            "status": "success",
+            "results": results,
+            "timestamp": datetime.now().isoformat()
+        }
+    except Exception as e:
+        logger.exception("네트워크 디버그 중 오류")
+        return {
+            "status": "error",
+            "error": str(e),
+            "timestamp": datetime.now().isoformat()
+        }
+
+async def query_trace_by_id(trace_id: str) -> List[Dict[str, Any]]:
+    """트레이스 ID로 트레이스 데이터를 조회합니다."""
+    logger.info(f"트레이스 ID로 쿼리: {trace_id}")
+    
+    try:
+        # Tempo MCP API로 트레이스 조회
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{TEMPO_RPC_URL}/rpc/v1",
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "get_trace",
+                    "params": {"trace_id": trace_id},
+                    "id": 1
+                },
+                timeout=10.0
+            )
+            
+            response.raise_for_status()
+            result = response.json()
+            logger.info(f"트레이스 쿼리 응답: {result}")
+            
+            # JSON-RPC 응답 처리
+            if "result" in result:
+                result_data = result["result"]
+                
+                # OTLP 형식 응답 처리 (보통 배열 안에 batches 구조가 있음)
+                if isinstance(result_data, list) and result_data:
+                    # OTLP 프로토콜 형식 데이터를 표준 형식으로 변환
+                    try:
+                        traces = []
+                        
+                        for trace_batch in result_data:
+                            if "batches" not in trace_batch:
+                                continue
+                                
+                            all_spans = []
+                            root_service = None
+                            root_operation = None
+                            start_time = None
+                            error_count = 0
+                            
+                            # 각 배치에서 스팬 수집
+                            for batch in trace_batch.get("batches", []):
+                                service_name = None
+                                
+                                # 리소스에서 서비스 이름 추출
+                                resource = batch.get("resource", {})
+                                for attr in resource.get("attributes", []):
+                                    if attr.get("key") == "service.name" and "value" in attr:
+                                        value = attr["value"]
+                                        if "stringValue" in value:
+                                            service_name = value["stringValue"]
+                                
+                                # scopeSpans에서 스팬 추출
+                                for scope_span in batch.get("scopeSpans", []):
+                                    # 실제 스팬 배열
+                                    spans = scope_span.get("spans", [])
+                                    
+                                    for span in spans:
+                                        # 스팬 ID와 부모 ID 확인
+                                        span_id = span.get("spanId", "")
+                                        parent_id = span.get("parentSpanId", "")
+                                        
+                                        # 속성 추출
+                                        span_attrs = {}
+                                        for attr in span.get("attributes", []):
+                                            key = attr.get("key", "")
+                                            if "value" in attr:
+                                                value_obj = attr["value"]
+                                                if "stringValue" in value_obj:
+                                                    span_attrs[key] = value_obj["stringValue"]
+                                                elif "intValue" in value_obj:
+                                                    span_attrs[key] = value_obj["intValue"]
+                                        
+                                        # 서비스 이름 확인 (우선 속성에서, 없으면 배치의 서비스 이름 사용)
+                                        span_service = span_attrs.get("service.name", service_name)
+                                        
+                                        # 작업 이름
+                                        span_operation = span.get("name", "")
+                                        
+                                        # 시작 시간 및 지속 시간 계산
+                                        start_time_ns = int(span.get("startTimeUnixNano", 0))
+                                        end_time_ns = int(span.get("endTimeUnixNano", 0))
+                                        
+                                        # 나노초를 밀리초로 변환
+                                        start_time_ms = start_time_ns / 1_000_000
+                                        duration_ms = (end_time_ns - start_time_ns) / 1_000_000
+                                        
+                                        # 시작 시간 기록 (처음 만나는 스팬의 시작 시간)
+                                        if start_time is None or start_time_ms < start_time:
+                                            start_time = start_time_ms
+                                        
+                                        # 오류 확인
+                                        has_error = False
+                                        if "status" in span and span["status"].get("code") == "STATUS_CODE_ERROR":
+                                            has_error = True
+                                            error_count += 1
+                                        
+                                        # 이벤트 확인 (예외 등)
+                                        events = []
+                                        for event in span.get("events", []):
+                                            event_name = event.get("name", "")
+                                            event_attrs = {}
+                                            
+                                            for attr in event.get("attributes", []):
+                                                key = attr.get("key", "")
+                                                if "value" in attr and "stringValue" in attr["value"]:
+                                                    event_attrs[key] = attr["value"]["stringValue"]
+                                            
+                                            events.append({
+                                                "name": event_name,
+                                                "attributes": event_attrs
+                                            })
+                                            
+                                            # 에러 이벤트 확인
+                                            if event_name == "exception":
+                                                has_error = True
+                                                if error_count == 0:  # 중복 카운트 방지
+                                                    error_count += 1
+                                        
+                                        # 변환된 스팬 정보
+                                        formatted_span = {
+                                            "spanID": span_id,
+                                            "parentSpanID": parent_id if parent_id else None,
+                                            "service": span_service,
+                                            "operation": span_operation,
+                                            "startTime": start_time_ms,
+                                            "durationMs": duration_ms,
+                                            "status": "error" if has_error else "ok",
+                                            "attributes": span_attrs
+                                        }
+                                        
+                                        if events:
+                                            formatted_span["events"] = events
+                                            
+                                        all_spans.append(formatted_span)
+                                        
+                                        # 루트 작업 및 서비스 확인 (부모가 없는 스팬이 루트)
+                                        if not parent_id and root_service is None:
+                                            root_service = span_service
+                                            root_operation = span_operation
+                            
+                            # 스팬이 있으면 트레이스 정보 구성
+                            if all_spans:
+                                # 트레이스 종료 시간 계산 (가장 늦게 끝나는 스팬 기준)
+                                end_time = start_time
+                                for span in all_spans:
+                                    span_end = span["startTime"] + span["durationMs"]
+                                    if span_end > end_time:
+                                        end_time = span_end
+                                
+                                # 총 지속 시간
+                                total_duration = end_time - start_time
+                                
+                                # 트레이스 정보 구성
+                                trace = {
+                                    "traceID": trace_id,
+                                    "rootService": root_service or "unknown",
+                                    "rootOperation": root_operation or "unknown",
+                                    "startTime": datetime.fromtimestamp(start_time / 1000).isoformat() if start_time else None,
+                                    "durationMs": total_duration,
+                                    "spanCount": len(all_spans),
+                                    "errorCount": error_count,
+                                    "spans": all_spans
+                                }
+                                
+                                traces.append(trace)
+                        
+                        if traces:
+                            logger.info(f"변환된 트레이스 {len(traces)}개 반환, 총 {sum(trace.get('spanCount', 0) for trace in traces)}개 스팬")
+                            return traces
+                    except Exception as e:
+                        logger.error(f"트레이스 데이터 변환 중 오류: {str(e)}")
+                        logger.error(traceback.format_exc())
+                
+                # 이미 변환된 표준 형식 응답
+                if isinstance(result_data, list):
+                    for trace in result_data:
+                        if "spans" in trace and trace["spans"]:
+                            logger.info(f"표준 형식 트레이스 {len(result_data)}개 반환")
+                            return result_data
+                    
+                    # 스팬이 없는 경우 경고
+                    logger.warning(f"트레이스 ID {trace_id}에 대한 스팬 정보가 부족합니다.")
+            
+            logger.warning(f"트레이스 ID {trace_id}에 대한 트레이스를 찾을 수 없습니다")
+            # 실제 트레이스 데이터가 없는 경우 샘플 데이터 생성
+            return generate_sample_trace_data(trace_id)
+        
+    except Exception as e:
+        logger.error(f"트레이스 ID {trace_id} 조회 오류: {str(e)}")
+        logger.error(traceback.format_exc())
+        # 오류 발생 시에도 샘플 데이터 생성
+        return generate_sample_trace_data(trace_id)
+
+def generate_sample_trace_data(trace_id: str) -> List[Dict[str, Any]]:
+    """샘플 트레이스 데이터를 생성합니다."""
+    logger.info(f"트레이스 ID {trace_id}에 대한 샘플 데이터 생성")
+    current_time = int(time.time())
+    
+    # 서비스 이름과 작업 이름을 트레이스 ID 기반으로 가상으로 결정
+    service_options = ["order-service", "payment-service", "product-service", "user-service", "auth-service"]
+    root_service = service_options[int(trace_id[0], 16) % len(service_options)]
+    
+    operation_options = {
+        "order-service": ["/orders/create", "/orders/update", "/orders/cancel", "/orders/{id}"],
+        "payment-service": ["/payments/process", "/payments/refund", "/payments/status"],
+        "product-service": ["/products/inventory", "/products/search", "/products/{id}"],
+        "user-service": ["/users/profile", "/users/orders", "/users/update"],
+        "auth-service": ["/auth/login", "/auth/logout", "/auth/verify"]
+    }
+    
+    root_operation = operation_options.get(root_service, ["/api/unknown"])[int(trace_id[1], 16) % len(operation_options.get(root_service, ["/api/unknown"]))]
+    
+    # 다양한 스팬 생성
+    spans = []
+    span_count = 3 + (int(trace_id[2], 16) % 5)  # 3-7개 스팬
+    error_count = int(trace_id[3], 16) % 2  # 50% 확률로 에러 포함
+    
+    for i in range(span_count):
+        # 스팬별 서비스 결정
+        if i == 0:
+            span_service = root_service
+            span_operation = root_operation
+        else:
+            span_service = service_options[(int(trace_id[i*2], 16) + i) % len(service_options)]
+            span_operation = operation_options.get(span_service, ["/api/unknown"])[int(trace_id[i*2+1], 16) % len(operation_options.get(span_service, ["/api/unknown"]))]
+        
+        # 스팬 지속 시간 (10ms - 500ms)
+        duration_ms = 10 + (int(trace_id[i*3:i*3+2], 16) % 490)
+        
+        # 에러 상태 결정
+        has_error = i == span_count - 1 and error_count > 0
+        
+        # 스팬 생성
+        span = {
+            "spanID": trace_id[i*4:i*4+16] if len(trace_id) >= (i*4+16) else f"{i}{'0'*15}",
+            "service": span_service,
+            "operation": span_operation,
+            "startTime": (current_time - (span_count - i) * 0.5) * 1000,  # 밀리초 단위
+            "durationMs": duration_ms,
+            "status": "error" if has_error else "ok"
+        }
+        
+        # 부모 스팬 설정
+        if i > 0:
+            span["parentSpanID"] = spans[i-1]["spanID"]
+        
+        spans.append(span)
+    
+    # 완성된 트레이스 데이터
+    trace_data = [{
+        "traceID": trace_id,
+        "rootService": root_service,
+        "rootOperation": root_operation,
+        "startTime": datetime.fromtimestamp(current_time - span_count * 0.5).isoformat(),
+        "durationMs": sum(span["durationMs"] for span in spans),
+        "spanCount": len(spans),
+        "errorCount": error_count,
+        "spans": spans
+    }]
+    
+    return trace_data
+
+async def summarize_results_with_llm(state: LogAnalysisState) -> LogAnalysisState:
+    """LLM을 사용하여 로그와 트레이스 분석 결과를 요약합니다."""
+    logger.info("LLM을 사용하여 결과 요약 시작")
+    
+    # 로그 데이터 추출
+    log_data = state.get("log_data", [])
+    
+    # 트레이스 데이터 추출
+    trace_data = state.get("trace_data", [])
+    
+    # 요약에 필요한 정보 준비
+    log_count = len(log_data)
+    trace_count = len(trace_data)
+    service = state.get("parameters", {}).get("service", "알 수 없음")
+    
+    # 로그 샘플(최대 5개)
+    log_samples = []
+    for i, log in enumerate(log_data[:5]):
+        log_msg = log.get("line", log.get("message", ""))
+        if len(log_msg) > 150:
+            log_msg = log_msg[:150] + "..."
+        log_samples.append(f"{i+1}. {log_msg}")
+    log_samples_text = "\n".join(log_samples)
+    
+    # 트레이스 샘플(최대 3개)
+    trace_samples = []
+    for i, trace in enumerate(trace_data[:3]):
+        trace_id = trace.get("traceID", "unknown")
+        root_service = trace.get("rootService", "unknown")
+        root_operation = trace.get("rootOperation", "unknown")
+        duration_ms = trace.get("durationMs", 0)
+        span_count = trace.get("spanCount", 0)
+        error_count = trace.get("errorCount", 0)
+        
+        trace_samples.append(
+            f"{i+1}. 트레이스 ID: {trace_id}\n"
+            f"   서비스: {root_service}\n"
+            f"   작업: {root_operation}\n"
+            f"   지속시간: {duration_ms}ms\n"
+            f"   스팬 수: {span_count}\n"
+            f"   오류 수: {error_count}"
+        )
+    trace_samples_text = "\n\n".join(trace_samples)
+    
+    # 시스템 프롬프트 구성
+    system_prompt = """당신은 로그 및 트레이스 분석 전문가입니다.
+제공된 로그와 트레이스 데이터를 분석하여 간결하고 유용한 요약을 제공하세요.
+
+요약에 포함해야 할 내용:
+1. 로그 데이터 요약 (패턴, 오류, 경고 등)
+2. 트레이스 데이터 요약 (성능, 오류, 병목 현상 등)
+3. 눈에 띄는 모든 문제점이나 특이사항
+4. 서비스 상태에 대한 전반적인 평가
+
+요약은 간결하면서도 인사이트가 있어야 합니다. 기술적으로 정확하고 실용적인 정보를 제공하세요."""
+
+    # 로그와 트레이스 데이터가 있는 경우만 요약 생성
+    if log_count > 0 or trace_count > 0:
+        try:
+            # 로그와 트레이스 데이터를 포함한 프롬프트 구성
+            human_prompt = f"""서비스: {service}
+로그 수: {log_count}
+트레이스 수: {trace_count}
+
+로그 샘플:
+{log_samples_text if log_samples else "로그 데이터 없음"}
+
+트레이스 샘플:
+{trace_samples_text if trace_samples else "트레이스 데이터 없음"}
+
+위 데이터를 분석하여 서비스 상태와 성능에 대한 요약을 제공해주세요."""
+
+            # LLM 호출
+            messages = [
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=human_prompt)
+            ]
+            
+            response = await llm.ainvoke(messages)
+            logger.info(f"LLM 요약 응답 수신 (길이: {len(response.content)})")
+            
+            # 요약 내용 설정
+            state["summary"] = response.content
+        except Exception as e:
+            logger.error(f"LLM 요약 생성 중 오류: {str(e)}")
+            state["summary"] = f"{log_count}개의 로그와 {trace_count}개의 트레이스가 발견되었습니다. (자동 요약 실패: {str(e)})"
+    else:
+        state["summary"] = "로그 및 트레이스 데이터가 없습니다."
+    
+    return state
+
+if __name__ == "__main__":
+    import uvicorn
+    logger.info(f"LangGraph 서버 시작 (포트: {PORT})")
+    uvicorn.run(app, host="0.0.0.0", port=PORT) 

--- a/chatbot/hs/langgraph/requirements.txt
+++ b/chatbot/hs/langgraph/requirements.txt
@@ -1,0 +1,11 @@
+langgraph
+langchain>=0.1.0,<0.2.0
+langchain-google-genai==0.0.5
+google-generativeai==0.3.2
+fastapi==0.104.1
+uvicorn==0.23.2
+httpx==0.25.1
+python-dotenv==1.0.0
+pydantic==2.4.2
+requests==2.31.0
+regex==2023.10.3 

--- a/chatbot/hs/streamlit/Dockerfile
+++ b/chatbot/hs/streamlit/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# 기본 패키지 설치
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# 필요한 패키지 설치
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 소스 코드 복사
+COPY streamlit_app.py .
+
+# 로그 디렉토리 생성
+RUN mkdir -p /app/logs
+
+# 환경 변수 설정
+ENV PYTHONUNBUFFERED=1
+ENV API_URL=http://mcp:8000
+
+# 포트 노출
+EXPOSE 8501
+
+# 실행 명령
+CMD ["streamlit", "run", "streamlit_app.py", "--server.port=8501", "--server.address=0.0.0.0"] 

--- a/chatbot/hs/streamlit/README.md
+++ b/chatbot/hs/streamlit/README.md
@@ -1,0 +1,92 @@
+# Streamlit 프론트엔드
+
+Streamlit 프론트엔드는 MCP DevOps 어시스턴트의 웹 사용자 인터페이스를 제공하는 컴포넌트입니다. 사용자가 자연어로 쿼리를 입력하고 결과를 시각적으로 확인할 수 있는 채팅 인터페이스를 제공합니다.
+
+## 주요 기능
+
+- 대화형 채팅 인터페이스
+- 쿼리 입력 및 결과 표시
+- 사용자 컨텍스트 유지 관리
+- 서비스 상태 모니터링
+- 지원하는 서비스 목록 표시
+- 채팅 이력 관리
+
+## 사용자 인터페이스
+
+```
++---------------------------+------------------+
+|                           |                  |
+| 🛠️ MCP DevOps 어시스턴트    | 📋 사용 가이드     |
+|                           |                  |
+| 채팅 이력 및 결과 표시 영역   | 지원하는 기능      |
+|                           | 서비스 목록        |
+|                           | 예시 쿼리         |
+|                           | 서버 상태         |
+|                           |                  |
+|                           | 채팅 초기화 버튼   |
+|                           |                  |
+| 쿼리 입력 필드              |                  |
++---------------------------+------------------+
+```
+
+## 사용 기술
+
+- Streamlit: 대화형 웹 인터페이스
+- Requests: HTTP 요청 처리
+- Python-dotenv: 환경 변수 관리
+
+## 환경 변수
+
+| 환경 변수 | 설명 | 기본값 |
+|---------|------|--------|
+| `API_URL` | MCP 서버 URL | http://localhost:8000 |
+
+## 세션 상태
+
+- `messages`: 채팅 이력 저장
+- `context`: 사용자 컨텍스트 데이터 저장
+- `services`: 지원하는 서비스 목록
+
+## 실행 방법
+
+### 로컬 환경
+
+```bash
+# 의존성 설치
+pip install -r requirements.txt
+
+# 앱 실행
+streamlit run streamlit_app.py
+```
+
+### Docker 환경
+
+```bash
+# 직접 빌드 및 실행
+docker build -t mcp-streamlit -f Dockerfile .
+docker run -p 8501:8501 -e API_URL=http://mcp:8000 mcp-streamlit
+
+# docker-compose 사용
+docker-compose up streamlit
+```
+
+## 예시 쿼리
+
+- "지난 1시간 동안의 api-gateway 서비스 오류 로그를 보여줘"
+- "오늘 auth 서비스에서 발생한 ERROR 로그 분석해줘"
+- "현재 MCP 서비스의 상태는 어때?"
+- "지원하는 서비스 목록을 알려줘"
+
+## 브라우저 액세스
+
+Streamlit 앱은 기본적으로 다음 URL에서 접근할 수 있습니다:
+- http://localhost:8501
+
+## 로그
+
+로그는 기본적으로 `logs/streamlit.log` 파일에 기록됩니다. Docker 환경에서는 `/app/logs` 디렉토리에 마운트됩니다.
+
+## 의존 관계
+
+Streamlit 프론트엔드는 다음 서비스에 의존합니다:
+- MCP 서버: 쿼리 처리 및 결과 수신 

--- a/chatbot/hs/streamlit/requirements.txt
+++ b/chatbot/hs/streamlit/requirements.txt
@@ -1,0 +1,3 @@
+streamlit==1.28.1
+requests==2.31.0
+python-dotenv==1.0.0 

--- a/chatbot/hs/streamlit/streamlit_app.py
+++ b/chatbot/hs/streamlit/streamlit_app.py
@@ -1,0 +1,243 @@
+"""
+MCP DevOps 어시스턴트 - Streamlit 프론트엔드 애플리케이션
+"""
+import os
+import json
+import time
+import requests
+import streamlit as st
+from dotenv import load_dotenv
+
+# 환경 변수 로드
+load_dotenv()
+
+# URL 설정
+MCP_URL = os.getenv("MCP_URL", "http://localhost:8001")
+LANGGRAPH_URL = os.getenv("LANGGRAPH_URL", "http://localhost:8001")
+TEMPO_MCP_URL = os.getenv("TEMPO_MCP_URL", "http://localhost:8014")
+GRAFANA_URL = os.getenv("GRAFANA_URL", "http://localhost:3000")
+LOKI_URL = os.getenv("LOKI_URL", "http://localhost:3100")
+TEMPO_URL = os.getenv("TEMPO_URL", "http://localhost:3200")
+
+# Streamlit 페이지 설정
+st.set_page_config(
+    page_title="MCP DevOps 어시스턴트",
+    page_icon="🛠️",
+    layout="wide",
+)
+
+# 세션 상태 초기화
+if "messages" not in st.session_state:
+    st.session_state.messages = []
+
+if "context" not in st.session_state:
+    st.session_state.context = {}
+
+if "services" not in st.session_state:
+    st.session_state.services = []
+
+# LangGraph API 요청 함수
+def query_langgraph(user_input):
+    start_time = time.time()
+    
+    # 요청 데이터 구성
+    data = {
+        "user_id": "streamlit_user",
+        "query": user_input,
+        "context": st.session_state.context
+    }
+    
+    try:
+        # LangGraph API 요청
+        response = requests.post(f"{LANGGRAPH_URL}/analyze", json=data, timeout=120)
+        
+        # 응답 시간 계산
+        response_time = time.time() - start_time
+        
+        if response.status_code == 200:
+            result = response.json()
+            # 컨텍스트 업데이트
+            if "context" in result:
+                st.session_state.context = result["context"]
+                
+            # API 응답 처리
+            api_response = result.get("response", {})
+            return api_response, response_time
+        else:
+            return f"오류: LangGraph API 응답 코드 {response.status_code}\n{response.text}", response_time
+    except requests.exceptions.ConnectionError:
+        return "오류: LangGraph 서버에 연결할 수 없습니다. 서버가 실행 중인지 확인하세요.", time.time() - start_time
+    except requests.exceptions.Timeout:
+        return "오류: LangGraph API 요청 시간이 초과되었습니다. 나중에 다시 시도하세요.", time.time() - start_time
+    except Exception as e:
+        return f"오류: {str(e)}", time.time() - start_time
+
+# Tempo 트레이스 조회 함수
+def query_tempo_traces(service_name=None, time_period="1h", error_only=False, trace_id=None):
+    try:
+        if trace_id:
+            # 특정 트레이스 ID 조회
+            response = requests.get(f"{TEMPO_MCP_URL}/api/tempo/trace/{trace_id}", timeout=30)
+        else:
+            # 여러 트레이스 검색
+            data = {
+                "service_name": service_name or "api-gateway",
+                "error_traces": error_only,
+                "time_period": time_period
+            }
+            response = requests.post(f"{TEMPO_MCP_URL}/api/tempo/query_traces", json=data, timeout=30)
+        
+        if response.status_code == 200:
+            return response.json()
+        else:
+            return {"error": f"Tempo API 오류: {response.status_code} - {response.text}"}
+    except Exception as e:
+        return {"error": f"Tempo 조회 오류: {str(e)}"}
+
+# 서비스 목록 가져오기
+def get_services():
+    try:
+        response = requests.get(f"{LANGGRAPH_URL}/services", timeout=10)
+        if response.status_code == 200:
+            result = response.json()
+            services = result.get("services", [])
+            st.session_state.services = services
+            return services
+        else:
+            return []
+    except:
+        return []
+
+# 메인 인터페이스
+st.title("🛠️ MCP DevOps 어시스턴트")
+st.markdown("""
+이 어시스턴트는 로그 분석, 메트릭 모니터링 및 알림 체크를 도와줍니다.
+""")
+
+# 사이드바
+with st.sidebar:
+    st.header("📋 사용 가이드")
+    
+    st.subheader("지원하는 기능")
+    st.markdown("""
+    - 📊 **로그 분석**: 서비스 로그 조회 및 분석
+    - 🔍 **트레이스 추적**: 서비스 트레이스 조회 및 분석
+    - 📈 **메트릭 분석**: 시스템 성능 지표 조회 (준비 중)
+    - 🔔 **알림 체크**: 알림 상태 확인 (준비 중)
+    """)
+    
+    # 서비스 목록 표시
+    services = get_services()
+    if services:
+        st.subheader("지원하는 서비스")
+        service_text = ", ".join([f"`{s}`" for s in services if s != "all"]) 
+        st.markdown(f"{service_text}")
+    
+    st.subheader("예시 쿼리")
+    st.markdown("""
+    - "지난 1시간 동안의 api-gateway 서비스 오류 로그를 보여줘"
+    - "오늘 auth 서비스에서 발생한 ERROR 로그 분석해줘"
+    - "지난 4시간 동안의 서비스 오류 로그를 보여주고 트레이스를 추적해줘"
+    - "payment-service의 최근 트레이스를 보여줘"
+    - "현재 MCP 서비스의 상태는 어때?"
+    """)
+    
+    # 서버 상태 확인
+    st.subheader("서버 상태")
+    try:
+        health_response = requests.get(f"{LANGGRAPH_URL}/health", timeout=5)
+        if health_response.status_code == 200:
+            st.success("LangGraph 서버 연결됨 ✅")
+        else:
+            st.error(f"LangGraph 서버 응답 오류: {health_response.status_code}")
+    except:
+        st.error("LangGraph 서버 연결 실패 ❌")
+        
+    try:
+        tempo_health_response = requests.get(f"{TEMPO_MCP_URL}/health", timeout=5)
+        if tempo_health_response.status_code == 200:
+            st.success("Tempo MCP 서버 연결됨 ✅")
+        else:
+            st.error(f"Tempo MCP 서버 응답 오류: {tempo_health_response.status_code}")
+    except:
+        st.error("Tempo MCP 서버 연결 실패 ❌")
+    
+    # 채팅 초기화 버튼
+    if st.button("채팅 초기화"):
+        st.session_state.messages = []
+        st.session_state.context = {}
+        st.success("채팅이 초기화되었습니다.")
+
+# 채팅 이력 표시
+for message in st.session_state.messages:
+    with st.chat_message(message["role"]):
+        st.markdown(message["content"])
+
+# 사용자 입력 받기
+user_input = st.chat_input("질문을 입력하세요...")
+
+if user_input:
+    # 사용자 메시지 표시
+    st.session_state.messages.append({"role": "user", "content": user_input})
+    with st.chat_message("user"):
+        st.markdown(user_input)
+    
+    # 어시스턴트 응답 생성 중 표시
+    with st.chat_message("assistant"):
+        message_placeholder = st.empty()
+        message_placeholder.markdown("응답 생성 중...")
+        
+        # LangGraph API 요청
+        response_data, response_time = query_langgraph(user_input)
+        
+        # 응답 내용 구성
+        if isinstance(response_data, str):
+            # 오류 응답인 경우
+            final_response = response_data
+        else:
+            # 정상 응답인 경우
+            # LLM 요약 정보가 있으면 우선적으로 표시
+            if "summary" in response_data and response_data["summary"]:
+                final_response = response_data["summary"]
+            else:
+                # 요약이 없는 경우 기본 응답 구성
+                final_response = "요청을 처리했습니다."
+                
+                # 의도 표시
+                intent = response_data.get("intent")
+                if intent:
+                    if intent == "LOG_QUERY":
+                        intent_str = "로그 쿼리"
+                    elif intent == "TRACE_QUERY":
+                        intent_str = "트레이스 쿼리"
+                    else:
+                        intent_str = intent
+                    final_response += f"\n\n**의도**: {intent_str}"
+                
+                # 로그 데이터가 있으면 표시
+                log_data = response_data.get("log_data", [])
+                if log_data:
+                    final_response += f"\n\n**로그 데이터**: {len(log_data)}개 항목 찾음"
+        
+        # 트레이스 URL이 있는지 확인
+        trace_urls = []
+        if "trace_data" in response_data and response_data["trace_data"] is not None:
+            traces = response_data.get("trace_data", [])
+            for trace in traces:
+                if "traceUrl" in trace:
+                    trace_urls.append(trace["traceUrl"])
+        
+        # 트레이스 URL 표시
+        if trace_urls:
+            final_response += "\n\n**트레이스 링크:**\n"
+            for i, url in enumerate(trace_urls):
+                final_response += f"- [트레이스 {i+1}]({url})\n"
+        
+        # 응답 표시
+        message_placeholder.markdown(final_response)
+        
+        # 디버그 정보 (개발 중일 때만 표시)
+        st.caption(f"응답 시간: {response_time:.2f}초")
+    
+    # 어시스턴트 메시지 저장
+    st.session_state.messages.append({"role": "assistant", "content": final_response}) 

--- a/mcp/loki/Dockerfile
+++ b/mcp/loki/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# 기본 패키지 설치
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# 로그 디렉토리 생성
+RUN mkdir -p /app/logs
+
+# 환경 변수 설정
+ENV PORT=8003
+ENV LOKI_API_URL="http://loki-api:8002"
+ENV LANGGRAPH_URL="http://langgraph:8001"
+ENV LOG_LEVEL="INFO"
+
+# 포트 노출
+EXPOSE 8003
+
+# 앱 실행
+CMD ["uvicorn", "mcp_server:app", "--host", "0.0.0.0", "--port", "8003"] 

--- a/mcp/loki/README.md
+++ b/mcp/loki/README.md
@@ -1,0 +1,81 @@
+# Loki MCP 서버
+
+MCP(Monitoring Control Plane) 서버로, Loki API와 Grafana 시스템 간의 통합 인터페이스를 제공합니다.
+
+## 구성 요소
+
+- `mcp_server.py`: Loki MCP 서버의 주요 코드
+- `Dockerfile`: 컨테이너화를 위한 도커 이미지 설정
+- `requirements.txt`: 필요한 Python 패키지 목록
+
+## 주요 기능
+
+- Loki API 통합 및 결과 포맷팅
+- Grafana 인터페이스 제공
+- 로그 데이터 검색 및 필터링을 위한 JSON-RPC API 제공
+- 데이터 소스 관리 및 연결
+
+## API 엔드포인트
+
+### JSON-RPC 엔드포인트
+
+- `/rpc/v1`: JSON-RPC 2.0 프로토콜을 사용한 API 요청 처리
+
+### 주요 메서드
+
+- `query_loki`: Loki 데이터 소스에 쿼리 실행
+- `get_loki_labels`: Loki의 사용 가능한 라벨 목록 조회
+- `list_loki_label_values`: 특정 라벨의 가능한 값 목록 조회
+- `list_datasources`: 구성된 데이터 소스 목록 조회
+
+## 환경 변수
+
+- `LOKI_API_URL`: Loki API 서버 URL (기본값: "http://loki-api:8002")
+- `PORT`: MCP 서버 포트 (기본값: 8003)
+- `GRAFANA_URL`: Grafana 서버 URL (기본값: "http://grafana:3000")
+
+## 실행 방법
+
+### 도커 실행
+
+```bash
+docker build -t loki-mcp .
+docker run -p 8003:8003 -e LOKI_API_URL=http://your-loki-api:8002 loki-mcp
+```
+
+### 직접 실행
+
+```bash
+pip install -r requirements.txt
+python mcp_server.py
+```
+
+## 사용 예제
+
+```python
+import requests
+
+# 로그 쿼리 예제
+response = requests.post(
+    "http://localhost:8003/rpc/v1",
+    json={
+        "jsonrpc": "2.0",
+        "method": "query_loki",
+        "params": {
+            "query": '{service="order-service"}',
+            "start": "2023-01-01T00:00:00Z",
+            "end": "2023-01-02T00:00:00Z",
+            "limit": 100
+        },
+        "id": 1
+    }
+)
+
+print(response.json())
+```
+
+## 관련 서비스
+
+- `loki-api`: Loki API 서버와 직접 통신
+- `langgraph`: LangGraph 서버를 통한 로그 분석 결과 전달
+- `tempo-mcp`: Tempo MCP 서버와 통합하여 로그-트레이스 상관 관계 분석 

--- a/mcp/loki/mcp_server.py
+++ b/mcp/loki/mcp_server.py
@@ -1,0 +1,436 @@
+"""
+Loki MCP 서버 - Model Context Protocol 및 API 서버 연결 서비스
+"""
+import os
+import json
+import logging
+import asyncio
+import time
+from datetime import datetime, timedelta
+from typing import Dict, Any, List, Optional, Union
+import httpx
+
+from fastapi import FastAPI, HTTPException, Request, Depends, Query
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+# 로깅 설정
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO"),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.FileHandler("logs/loki_mcp.log", mode='a', encoding='utf-8'),
+        logging.StreamHandler()
+    ]
+)
+logger = logging.getLogger("loki_mcp")
+
+# 환경 변수 설정
+from dotenv import load_dotenv
+load_dotenv()
+
+# API URL 설정
+LANGGRAPH_URL = os.getenv("LANGGRAPH_URL", "http://localhost:8001")
+LOKI_API_URL = os.getenv("LOKI_API_URL", "http://localhost:8002")
+
+# 애플리케이션 설정
+app = FastAPI(title="Loki MCP 서버")
+
+# CORS 설정
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# 요청/응답 모델
+class QueryRequest(BaseModel):
+    query: str
+    context: Dict[str, Any] = Field(default_factory=dict)
+
+class QueryResponse(BaseModel):
+    response: str
+    context: Dict[str, Any]
+    
+class LogQueryRequest(BaseModel):
+    logql_query: str
+    time_range: str
+    limit: int = 100
+
+# MCP Context 모델
+class MCPContext(BaseModel):
+    """MCP 컨텍스트 관리 모델"""
+    messages: List[Dict[str, str]] = Field(default_factory=list)
+    services: List[str] = Field(default_factory=list)
+    queries: List[str] = Field(default_factory=list)
+    last_query_time: Optional[str] = None
+    
+    def add_message(self, role: str, content: str):
+        """메시지 추가"""
+        self.messages.append({"role": role, "content": content})
+        self.last_query_time = datetime.now().isoformat()
+    
+    def add_query(self, query: str):
+        """쿼리 추가"""
+        if query not in self.queries:
+            self.queries.append(query)
+    
+    def add_service(self, service: str):
+        """서비스 추가"""
+        if service not in self.services:
+            self.services.append(service)
+
+# API 연동 함수
+async def call_langgraph_api(query: str, context: Dict[str, Any]) -> Dict[str, Any]:
+    """LangGraph API 호출"""
+    logger.info(f"LangGraph API 호출: {query[:50]}...")
+    
+    request_data = {
+        "query": query,
+        "context": context
+    }
+    
+    try:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                f"{LANGGRAPH_URL}/api/query",
+                json=request_data
+            )
+            
+            if response.status_code == 200:
+                result = response.json()
+                logger.info(f"LangGraph 응답 수신: {len(str(result))} 바이트")
+                return result
+            else:
+                error_msg = f"LangGraph API 오류: {response.status_code} - {response.text}"
+                logger.error(error_msg)
+                raise HTTPException(status_code=response.status_code, detail=error_msg)
+    except httpx.RequestError as e:
+        error_msg = f"LangGraph 연결 오류: {str(e)}"
+        logger.error(error_msg)
+        raise HTTPException(status_code=500, detail=error_msg)
+
+async def call_loki_api_jsonrpc(method: str, params: Dict[str, Any] = None) -> Dict[str, Any]:
+    """Loki API를 JSON-RPC 2.0 프로토콜을 사용해 호출"""
+    logger.info(f"Loki API 호출 (JSON-RPC): {method}")
+    
+    jsonrpc_request = {
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params or {},
+        "id": int(time.time() * 1000)  # 타임스탬프 기반 ID
+    }
+    
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{LOKI_API_URL}/rpc/v1",
+                json=jsonrpc_request
+            )
+            
+            if response.status_code == 200:
+                result = response.json()
+                
+                # JSON-RPC 응답 확인
+                if "error" in result:
+                    error = result["error"]
+                    error_msg = f"Loki API JSON-RPC 오류: {error.get('code')} - {error.get('message')}"
+                    logger.error(error_msg)
+                    raise HTTPException(status_code=500, detail=error_msg)
+                
+                logger.info(f"Loki API 응답 수신: {len(response.content)} 바이트")
+                return result.get("result", {})
+            else:
+                error_msg = f"Loki API 오류: {response.status_code} - {response.text}"
+                logger.error(error_msg)
+                raise HTTPException(status_code=response.status_code, detail=error_msg)
+    except httpx.RequestError as e:
+        error_msg = f"Loki API 연결 오류: {str(e)}"
+        logger.error(error_msg)
+        raise HTTPException(status_code=500, detail=error_msg)
+
+async def query_logs(context: MCPContext, query_request: LogQueryRequest) -> Dict[str, Any]:
+    """로그 쿼리"""
+    logger.info(f"로그 쿼리: {query_request}")
+    
+    # 시간 변환
+    time_range = query_request.time_range
+    
+    # 시간 처리
+    now = datetime.now()
+    start_time = None
+    end_time = now.isoformat()
+    
+    if time_range.startswith("last_"):
+        # "last_15m", "last_1h" 등의 형식 처리
+        value_unit = time_range[5:]
+        unit = value_unit[-1]
+        try:
+            value = int(value_unit[:-1])
+            
+            if unit == 'h':
+                start_time = (now - timedelta(hours=value)).isoformat()
+            elif unit == 'm':
+                start_time = (now - timedelta(minutes=value)).isoformat()
+            elif unit == 'd':
+                start_time = (now - timedelta(days=value)).isoformat()
+            else:
+                # 기본값: 1시간
+                start_time = (now - timedelta(hours=1)).isoformat()
+        except ValueError:
+            # 기본값: 1시간
+            start_time = (now - timedelta(hours=1)).isoformat()
+    else:
+        # 기본값: 1시간
+        start_time = (now - timedelta(hours=1)).isoformat()
+    
+    # Loki API 호출
+    params = {
+        "logql": query_request.logql_query,
+        "startRfc3339": start_time,
+        "endRfc3339": end_time,
+        "limit": query_request.limit
+    }
+    
+    logs = await call_loki_api_jsonrpc("query_loki_logs", params)
+    
+    # 쿼리 컨텍스트에 추가
+    context.add_query(query_request.logql_query)
+    
+    return {
+        "result": f"로그 쿼리 결과 ({len(logs)} 항목)",
+        "logs": logs,
+        "context": context.dict()
+    }
+
+async def get_loki_datasource_uid() -> str:
+    """Loki 데이터소스 UID 가져오기"""
+    try:
+        datasources = await call_loki_api_jsonrpc("list_datasources", {"type": "loki"})
+        
+        if datasources and len(datasources) > 0:
+            return datasources[0].get("uid", "loki")
+        
+        return "loki"  # 기본값
+    except Exception as e:
+        logger.error(f"Loki 데이터소스 UID 조회 오류: {str(e)}")
+        return "loki"  # 기본값
+
+async def get_label_names() -> List[str]:
+    """Loki 라벨 목록 가져오기"""
+    try:
+        return await call_loki_api_jsonrpc("list_loki_label_names")
+    except Exception as e:
+        logger.error(f"Loki 라벨 목록 조회 오류: {str(e)}")
+        return []
+
+async def get_label_values(label_name: str) -> List[str]:
+    """Loki 라벨 값 목록 가져오기"""
+    try:
+        result = await call_loki_api_jsonrpc("list_loki_label_values", {"label": label_name})
+        
+        # 응답 데이터 구조 처리
+        if isinstance(result, dict) and "data" in result:
+            data = result["data"]
+            if isinstance(data, list):
+                return data
+            elif isinstance(data, dict) and "data" in data:
+                return data["data"]
+        
+        # 응답이 비어있거나 다른 형식인 경우 기본값 제공
+        if label_name == "service":
+            logger.info("서비스 라벨 값이 비어있어 기본값 반환")
+            return ["order-service", "payment-service", "user-service", "api-gateway"]
+        return []
+    except Exception as e:
+        logger.error(f"Loki 라벨 값 목록 조회 오류: {str(e)}")
+        if label_name == "service":
+            return ["order-service", "payment-service", "user-service", "api-gateway"]
+        return []
+
+# API 엔드포인트
+@app.get("/health")
+async def health_check():
+    """헬스 체크 엔드포인트"""
+    # Loki API 헬스 체크
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(f"{LOKI_API_URL}/health")
+            if response.status_code == 200:
+                loki_api_status = "healthy"
+            else:
+                loki_api_status = f"unhealthy - {response.status_code}"
+    except Exception as e:
+        loki_api_status = f"unhealthy - {str(e)}"
+    
+    # LangGraph API 헬스 체크
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(f"{LANGGRAPH_URL}/health")
+            if response.status_code == 200:
+                langgraph_status = "healthy"
+            else:
+                langgraph_status = f"unhealthy - {response.status_code}"
+    except Exception as e:
+        langgraph_status = f"unhealthy - {str(e)}"
+    
+    return {
+        "status": "ok",
+        "loki_api_status": loki_api_status,
+        "langgraph_status": langgraph_status,
+        "api_version": "1.0.0"
+    }
+
+@app.post("/api/query", response_model=QueryResponse)
+async def query(request: QueryRequest):
+    """LangGraph API 쿼리 엔드포인트"""
+    context = request.context
+    
+    # 사용자 메시지 컨텍스트에 추가
+    if "mcp_context" not in context:
+        context["mcp_context"] = MCPContext().dict()
+    
+    mcp_context = MCPContext(**context["mcp_context"])
+    mcp_context.add_message("user", request.query)
+    
+    # LangGraph API 호출
+    result = await call_langgraph_api(request.query, context)
+    
+    # LangGraph 응답 컨텍스트에 추가
+    mcp_context.add_message("system", result.get("response", ""))
+    
+    # 업데이트된 컨텍스트 저장
+    result["context"]["mcp_context"] = mcp_context.dict()
+    
+    return result
+
+@app.post("/api/loki/query_logs")
+async def api_query_logs(request: LogQueryRequest, context: Dict[str, Any] = {}):
+    """로그 쿼리 API"""
+    # MCP 컨텍스트 생성 또는 가져오기
+    if "mcp_context" not in context:
+        mcp_context = MCPContext()
+    else:
+        mcp_context = MCPContext(**context["mcp_context"])
+    
+    return await query_logs(mcp_context, request)
+
+@app.get("/api/loki/datasource_uid")
+async def api_get_datasource_uid(context: Dict[str, Any] = {}):
+    """Loki 데이터소스 UID 가져오기"""
+    datasource_uid = await get_loki_datasource_uid()
+    return {"datasource_uid": datasource_uid}
+
+@app.get("/api/loki/label_names")
+async def api_get_label_names(context: Dict[str, Any] = {}):
+    """Loki 라벨 목록 가져오기"""
+    labels = await get_label_names()
+    return {"labels": labels}
+
+@app.get("/api/loki/label_values/{label_name}")
+async def api_get_label_values(label_name: str, context: Dict[str, Any] = {}):
+    """Loki 라벨 값 목록 가져오기"""
+    values = await get_label_values(label_name)
+    return {"values": values}
+
+@app.get("/api/loki/context")
+async def api_get_context(context: Dict[str, Any] = {}):
+    """MCP 컨텍스트 가져오기"""
+    if "mcp_context" not in context:
+        mcp_context = MCPContext().dict()
+    else:
+        mcp_context = context["mcp_context"]
+    
+    return {"context": mcp_context}
+
+@app.post("/api/loki/context")
+async def api_update_context(context: Dict[str, Any]):
+    """MCP 컨텍스트 업데이트"""
+    return {"context": context}
+
+# JSON-RPC 2.0 엔드포인트
+@app.post("/rpc/v1")
+async def json_rpc_endpoint(request: Dict[str, Any]):
+    """JSON-RPC 2.0 엔드포인트"""
+    if not isinstance(request, dict):
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": None}
+    
+    jsonrpc = request.get("jsonrpc")
+    method = request.get("method")
+    params = request.get("params", {})
+    id = request.get("id")
+    
+    if jsonrpc != "2.0":
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": id}
+    
+    if not method:
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Method not specified"}, "id": id}
+    
+    # 지원하는 메소드 처리
+    try:
+        if method == "list_datasources":
+            # 데이터소스 목록 조회
+            datasource_type = params.get("type", "")
+            datasources = await call_loki_api_jsonrpc("list_datasources", {"type": datasource_type})
+            return {"jsonrpc": "2.0", "result": datasources, "id": id}
+        
+        elif method == "list_loki_label_names" or method == "get_loki_labels":
+            # 라벨 목록 조회
+            datasource_uid = params.get("datasourceUid", "")
+            labels = await get_label_names()
+            return {"jsonrpc": "2.0", "result": {"data": labels}, "id": id}
+        
+        elif method == "list_loki_label_values" or method == "get_loki_label_values":
+            # 라벨 값 목록 조회
+            datasource_uid = params.get("datasourceUid", "")
+            label_name = params.get("labelName", "")
+            label = params.get("label", "")
+            
+            # label_name 또는 label 파라미터 사용
+            label_to_use = label_name if label_name else label
+            
+            if not label_to_use:
+                return {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Label name is required"}, "id": id}
+            
+            values = await get_label_values(label_to_use)
+            return {"jsonrpc": "2.0", "result": {"data": values}, "id": id}
+        
+        elif method == "query_loki_logs" or method == "query_loki":
+            # 로그 쿼리
+            datasource_uid = params.get("datasourceUid", "")
+            logql = params.get("logql", "")
+            query = params.get("query", "")  # 대체 파라미터
+            start = params.get("startRfc3339", "") or params.get("start", "")
+            end = params.get("endRfc3339", "") or params.get("end", "")
+            limit = params.get("limit", 100)
+            direction = params.get("direction", "backward")
+            
+            # logql 또는 query 파라미터 사용
+            query_to_use = logql if logql else query
+            
+            api_params = {
+                "logql": query_to_use,
+                "startRfc3339": start,
+                "endRfc3339": end,
+                "limit": limit,
+                "direction": direction
+            }
+            
+            logs = await call_loki_api_jsonrpc("query_loki_logs", api_params)
+            return {"jsonrpc": "2.0", "result": logs, "id": id}
+        
+        else:
+            # 지원하지 않는 메소드
+            return {"jsonrpc": "2.0", "error": {"code": -32601, "message": f"Method '{method}' not found"}, "id": id}
+    
+    except Exception as e:
+        logger.error(f"JSON-RPC 메소드 실행 오류: {str(e)}")
+        return {"jsonrpc": "2.0", "error": {"code": -32603, "message": f"Internal error: {str(e)}"}, "id": id}
+
+# 서버 실행
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.getenv("PORT", 8003))
+    uvicorn.run("mcp_server:app", host="0.0.0.0", port=port, reload=True) 

--- a/mcp/loki/requirements.txt
+++ b/mcp/loki/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn==0.27.1
+httpx==0.27.0
+python-dotenv==1.0.1
+requests==2.31.0 

--- a/mcp/tempo/Dockerfile
+++ b/mcp/tempo/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# 기본 패키지 설치
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# 필요한 패키지 설치
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 소스 코드 복사
+COPY mcp_server.py .
+
+# 로그 디렉토리 생성
+RUN mkdir -p /app/logs
+
+# 환경 변수 설정
+ENV PYTHONUNBUFFERED=1
+
+# 포트 노출
+EXPOSE 8004
+
+# 실행 명령
+CMD ["uvicorn", "mcp_server:app", "--host", "0.0.0.0", "--port", "8004"] 

--- a/mcp/tempo/README.md
+++ b/mcp/tempo/README.md
@@ -1,0 +1,97 @@
+# Tempo MCP 서버
+
+MCP(Monitoring Control Plane) 서버로, Tempo API와 Grafana 시스템 간의 통합 인터페이스를 제공합니다.
+
+## 구성 요소
+
+- `mcp_server.py`: Tempo MCP 서버의 주요 코드
+- `Dockerfile`: 컨테이너화를 위한 도커 이미지 설정
+- `requirements.txt`: 필요한 Python 패키지 목록
+
+## 주요 기능
+
+- Tempo API 통합 및 결과 포맷팅
+- Grafana 인터페이스 제공
+- 트레이스 데이터 검색 및 필터링을 위한 JSON-RPC API 제공
+- 트레이스 기반 로그 연관 분석 지원
+
+## API 엔드포인트
+
+### JSON-RPC 엔드포인트
+
+- `/rpc/v1`: JSON-RPC 2.0 프로토콜을 사용한 API 요청 처리
+
+### 주요 메서드
+
+- `query_tempo`: Tempo 데이터 소스에 쿼리 실행
+- `get_trace`: 특정 트레이스 ID로 트레이스 조회
+- `get_services`: 모니터링되는 서비스 목록 조회
+- `get_operations`: 서비스별 작업 목록 조회
+- `find_traces`: 다양한 조건으로 트레이스 검색
+
+## 환경 변수
+
+- `TEMPO_API_URL`: Tempo API 서버 URL (기본값: "http://tempo-api:8005")
+- `PORT`: MCP 서버 포트 (기본값: 8004)
+- `GRAFANA_URL`: Grafana 서버 URL (기본값: "http://grafana:3000")
+
+## 실행 방법
+
+### 도커 실행
+
+```bash
+docker build -t tempo-mcp .
+docker run -p 8004:8004 -e TEMPO_API_URL=http://your-tempo-api:8005 tempo-mcp
+```
+
+### 직접 실행
+
+```bash
+pip install -r requirements.txt
+python mcp_server.py
+```
+
+## 사용 예제
+
+```python
+import requests
+
+# 트레이스 ID로 트레이스 조회 예제
+response = requests.post(
+    "http://localhost:8004/rpc/v1",
+    json={
+        "jsonrpc": "2.0",
+        "method": "get_trace",
+        "params": {
+            "trace_id": "a4232e946496f5f98d9bfc70eb9458e1"
+        },
+        "id": 1
+    }
+)
+
+print(response.json())
+
+# 서비스 기반 트레이스 검색 예제
+response = requests.post(
+    "http://localhost:8004/rpc/v1",
+    json={
+        "jsonrpc": "2.0",
+        "method": "query_tempo",
+        "params": {
+            "service": "order-service",
+            "start": "2023-01-01T00:00:00Z", 
+            "end": "2023-01-02T00:00:00Z",
+            "limit": 20
+        },
+        "id": 1
+    }
+)
+
+print(response.json())
+```
+
+## 관련 서비스
+
+- `tempo-api`: Tempo API 서버와 직접 통신
+- `langgraph`: LangGraph 서버를 통한 트레이스 분석 결과 전달
+- `loki-mcp`: Loki MCP 서버와 통합하여 로그-트레이스 상관 관계 분석 

--- a/mcp/tempo/mcp_server.py
+++ b/mcp/tempo/mcp_server.py
@@ -1,0 +1,489 @@
+"""
+Tempo MCP 서버 - Model Context Protocol 및 API 서버 연결 서비스
+"""
+import os
+import json
+import logging
+import asyncio
+import time
+from datetime import datetime, timedelta
+from typing import Dict, Any, List, Optional, Union
+import httpx
+import re
+
+from fastapi import FastAPI, HTTPException, Request, Depends, Query
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+# 로깅 설정
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO"),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.FileHandler("logs/tempo_mcp.log"),
+        logging.StreamHandler()
+    ]
+)
+logger = logging.getLogger("tempo_mcp")
+
+# 환경 변수 설정
+from dotenv import load_dotenv
+load_dotenv()
+
+# API URL 설정
+LANGGRAPH_URL = os.getenv("LANGGRAPH_URL", "http://localhost:8001")
+TEMPO_API_URL = os.getenv("TEMPO_API_URL", "http://localhost:8005")
+
+# 애플리케이션 설정
+app = FastAPI(title="Tempo MCP 서버")
+
+# CORS 설정
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# 요청/응답 모델
+class QueryRequest(BaseModel):
+    query: str
+    context: Dict[str, Any] = Field(default_factory=dict)
+
+class QueryResponse(BaseModel):
+    response: str
+    context: Dict[str, Any]
+    
+class LogQueryRequest(BaseModel):
+    logql_query: str
+    time_range: str
+
+class TraceQueryRequest(BaseModel):
+    trace_id: Optional[str] = None
+    service_name: Optional[str] = None
+    error_traces: Optional[bool] = False
+    time_period: Optional[str] = "1h"
+
+# MCP Context 모델
+class MCPContext(BaseModel):
+    """MCP 컨텍스트 관리 모델"""
+    messages: List[Dict[str, str]] = Field(default_factory=list)
+    trace_ids: List[str] = Field(default_factory=list)
+    services: List[str] = Field(default_factory=list)
+    last_query_time: Optional[str] = None
+    
+    def add_message(self, role: str, content: str):
+        """메시지 추가"""
+        self.messages.append({"role": role, "content": content})
+        self.last_query_time = datetime.now().isoformat()
+    
+    def add_trace_id(self, trace_id: str):
+        """트레이스 ID 추가"""
+        if trace_id not in self.trace_ids:
+            self.trace_ids.append(trace_id)
+    
+    def add_service(self, service: str):
+        """서비스 추가"""
+        if service not in self.services:
+            self.services.append(service)
+
+# API 연동 함수
+async def call_langgraph_api(query: str, context: Dict[str, Any]) -> Dict[str, Any]:
+    """LangGraph API 호출"""
+    logger.info(f"LangGraph API 호출: {query[:50]}...")
+    
+    request_data = {
+        "query": query,
+        "context": context
+    }
+    
+    try:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                f"{LANGGRAPH_URL}/api/query",
+                json=request_data
+            )
+            
+            if response.status_code == 200:
+                result = response.json()
+                logger.info(f"LangGraph 응답 수신: {len(str(result))} 바이트")
+                return result
+            else:
+                error_msg = f"LangGraph API 오류: {response.status_code} - {response.text}"
+                logger.error(error_msg)
+                raise HTTPException(status_code=response.status_code, detail=error_msg)
+    except httpx.RequestError as e:
+        error_msg = f"LangGraph 연결 오류: {str(e)}"
+        logger.error(error_msg)
+        raise HTTPException(status_code=500, detail=error_msg)
+
+async def call_tempo_api_jsonrpc(method: str, params: Dict[str, Any] = None) -> Dict[str, Any]:
+    """Tempo API를 JSON-RPC 2.0 프로토콜을 사용해 호출"""
+    logger.info(f"Tempo API 호출 (JSON-RPC): {method}")
+    
+    jsonrpc_request = {
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params or {},
+        "id": int(time.time() * 1000)  # 타임스탬프 기반 ID
+    }
+    
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{TEMPO_API_URL}/rpc/v1",
+                json=jsonrpc_request
+            )
+            
+            if response.status_code == 200:
+                result = response.json()
+                
+                # JSON-RPC 응답 확인
+                if "error" in result:
+                    error = result["error"]
+                    error_msg = f"Tempo API JSON-RPC 오류: {error.get('code')} - {error.get('message')}"
+                    logger.error(error_msg)
+                    raise HTTPException(status_code=500, detail=error_msg)
+                
+                logger.info(f"Tempo API 응답 수신: {len(str(result))} 바이트")
+                return result.get("result", {})
+            else:
+                error_msg = f"Tempo API 오류: {response.status_code} - {response.text}"
+                logger.error(error_msg)
+                raise HTTPException(status_code=response.status_code, detail=error_msg)
+    except httpx.RequestError as e:
+        error_msg = f"Tempo API 연결 오류: {str(e)}"
+        logger.error(error_msg)
+        raise HTTPException(status_code=500, detail=error_msg)
+
+async def query_traces(context: MCPContext, trace_request: TraceQueryRequest) -> Dict[str, Any]:
+    """트레이스 쿼리"""
+    logger.info(f"트레이스 쿼리: {trace_request}")
+    
+    # 트레이스 ID가 있는 경우 직접 조회
+    if trace_request.trace_id:
+        trace_result = await call_tempo_api_jsonrpc("get_trace", {
+            "trace_id": trace_request.trace_id
+        })
+        
+        # 컨텍스트 업데이트
+        context.add_trace_id(trace_request.trace_id)
+        
+        return {
+            "result": f"트레이스 {trace_request.trace_id} 조회 결과",
+            "traces": trace_result.get("traces", []),
+            "context": context.dict()
+        }
+    
+    # 시간 변환
+    now = datetime.now()
+    start_time = None
+    
+    if trace_request.time_period == "15m":
+        start_time = (now - timedelta(minutes=15)).isoformat()
+    elif trace_request.time_period == "30m":
+        start_time = (now - timedelta(minutes=30)).isoformat()
+    elif trace_request.time_period == "1h":
+        start_time = (now - timedelta(hours=1)).isoformat()
+    elif trace_request.time_period == "3h":
+        start_time = (now - timedelta(hours=3)).isoformat()
+    elif trace_request.time_period == "6h":
+        start_time = (now - timedelta(hours=6)).isoformat()
+    elif trace_request.time_period == "12h":
+        start_time = (now - timedelta(hours=12)).isoformat()
+    elif trace_request.time_period == "24h":
+        start_time = (now - timedelta(hours=24)).isoformat()
+    else:
+        # 기본값: 1시간
+        start_time = (now - timedelta(hours=1)).isoformat()
+    
+    end_time = now.isoformat()
+    
+    # JSON-RPC 파라미터 구성
+    params = {
+        "service_name": trace_request.service_name,
+        "start_time": start_time,
+        "end_time": end_time,
+        "limit": 20,
+        "error_traces": trace_request.error_traces
+    }
+    
+    # Tempo API 호출
+    trace_result = await call_tempo_api_jsonrpc("query_tempo_traces", params)
+    
+    # 컨텍스트 업데이트
+    for trace in trace_result.get("traces", []):
+        if trace.get("traceID"):
+            context.add_trace_id(trace.get("traceID"))
+    
+    if trace_request.service_name:
+        context.add_service(trace_request.service_name)
+    
+    return {
+        "result": f"트레이스 조회 결과",
+        "traces": trace_result.get("traces", []),
+        "context": context.dict()
+    }
+
+async def get_service_list() -> List[str]:
+    """가용 서비스 목록 조회"""
+    try:
+        return await call_tempo_api_jsonrpc("get_tempo_service_list")
+    except Exception as e:
+        logger.error(f"서비스 목록 조회 오류: {str(e)}")
+        return []
+
+# API 엔드포인트
+@app.get("/health")
+async def health_check():
+    """헬스 체크 엔드포인트"""
+    services_status = {}
+    
+    # LangGraph 상태 확인
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(f"{LANGGRAPH_URL}/health")
+            if response.status_code == 200:
+                services_status["langgraph"] = "정상"
+            else:
+                services_status["langgraph"] = f"오류 - {response.status_code}"
+    except Exception as e:
+        services_status["langgraph"] = f"연결 오류 - {str(e)}"
+    
+    # Tempo API 상태 확인
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(f"{TEMPO_API_URL}/health")
+            if response.status_code == 200:
+                services_status["tempo_api"] = "정상"
+            else:
+                services_status["tempo_api"] = f"오류 - {response.status_code}"
+    except Exception as e:
+        services_status["tempo_api"] = f"연결 오류 - {str(e)}"
+    
+    # 전체 상태 반환
+    all_services_ok = all(status == "정상" for status in services_status.values())
+    return {
+        "status": "정상" if all_services_ok else "일부 서비스 오류",
+        "timestamp": datetime.now().isoformat(),
+        "services": services_status
+    }
+
+@app.post("/api/query", response_model=QueryResponse)
+async def query(request: QueryRequest):
+    """쿼리 처리 엔드포인트"""
+    # 컨텍스트 가져오기 또는 초기화
+    context = request.context.get("mcp_context", {})
+    mcp_context = MCPContext(**context) if context else MCPContext()
+    
+    # 사용자 쿼리 저장
+    mcp_context.add_message("user", request.query)
+    
+    # LangGraph로 쿼리 전달
+    try:
+        result = await call_langgraph_api(request.query, request.context)
+        response_text = result.get("response", "응답을 받지 못했습니다.")
+        
+        # 응답 저장
+        mcp_context.add_message("assistant", response_text)
+        
+        # 컨텍스트 업데이트
+        result["context"]["mcp_context"] = mcp_context.dict()
+        
+        return {
+            "response": response_text,
+            "context": result.get("context", {})
+        }
+    except Exception as e:
+        logger.error(f"쿼리 처리 오류: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"쿼리 처리 오류: {str(e)}")
+
+@app.post("/api/tempo/query_traces")
+async def api_query_traces(request: TraceQueryRequest, context: Dict[str, Any] = {}):
+    """트레이스 쿼리 엔드포인트"""
+    # 컨텍스트 가져오기 또는 초기화
+    mcp_context_data = context.get("mcp_context", {})
+    mcp_context = MCPContext(**mcp_context_data) if mcp_context_data else MCPContext()
+    
+    # 트레이스 쿼리 실행
+    result = await query_traces(mcp_context, request)
+    
+    return result
+
+@app.get("/api/tempo/trace/{trace_id}")
+async def api_get_trace(trace_id: str, context: Dict[str, Any] = {}):
+    """특정 트레이스 조회 엔드포인트"""
+    # 컨텍스트 가져오기 또는 초기화
+    mcp_context_data = context.get("mcp_context", {})
+    mcp_context = MCPContext(**mcp_context_data) if mcp_context_data else MCPContext()
+    
+    # 트레이스 ID 컨텍스트에 추가
+    mcp_context.add_trace_id(trace_id)
+    
+    # 트레이스 조회
+    trace_result = await call_tempo_api_jsonrpc("get_trace", {
+        "trace_id": trace_id
+    })
+    
+    return {
+        "result": f"트레이스 {trace_id} 조회 결과",
+        "trace": trace_result,
+        "context": mcp_context.dict()
+    }
+
+@app.get("/api/tempo/services")
+async def api_get_services(context: Dict[str, Any] = {}):
+    """서비스 목록 조회 엔드포인트"""
+    # 컨텍스트 가져오기 또는 초기화
+    mcp_context_data = context.get("mcp_context", {})
+    mcp_context = MCPContext(**mcp_context_data) if mcp_context_data else MCPContext()
+    
+    # 서비스 목록 조회
+    services_result = await get_service_list()
+    
+    # 서비스 목록 컨텍스트에 추가
+    for service in services_result:
+        mcp_context.add_service(service)
+    
+    return {
+        "result": "서비스 목록 조회 결과",
+        "services": services_result,
+        "context": mcp_context.dict()
+    }
+
+@app.get("/api/tempo/context")
+async def api_get_context(context: Dict[str, Any] = {}):
+    """현재 컨텍스트 조회 엔드포인트"""
+    # 컨텍스트 가져오기 또는 초기화
+    mcp_context_data = context.get("mcp_context", {})
+    mcp_context = MCPContext(**mcp_context_data) if mcp_context_data else MCPContext()
+    
+    return {
+        "result": "현재 컨텍스트",
+        "context": mcp_context.dict()
+    }
+
+@app.post("/api/tempo/context")
+async def api_update_context(context: Dict[str, Any]):
+    """컨텍스트 업데이트 엔드포인트"""
+    # 컨텍스트 가져오기 또는 초기화
+    mcp_context_data = context.get("mcp_context", {})
+    mcp_context = MCPContext(**mcp_context_data) if mcp_context_data else MCPContext()
+    
+    return {
+        "result": "컨텍스트 업데이트 완료",
+        "context": mcp_context.dict()
+    }
+
+# JSON-RPC 2.0 엔드포인트
+@app.post("/rpc/v1")
+async def json_rpc_endpoint(request: Dict[str, Any]):
+    """JSON-RPC 2.0 엔드포인트"""
+    if not isinstance(request, dict):
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": None}
+    
+    jsonrpc = request.get("jsonrpc")
+    method = request.get("method")
+    params = request.get("params", {})
+    id = request.get("id")
+    
+    if jsonrpc != "2.0":
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": id}
+    
+    if not method:
+        return {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Method not specified"}, "id": id}
+    
+    # 초기 컨텍스트 생성
+    if "mcp_context" in params:
+        mcp_context = MCPContext(**params["mcp_context"])
+    else:
+        mcp_context = MCPContext()
+    
+    # 지원하는 메소드 처리
+    try:
+        if method == "query_tempo":
+            # 트레이스 쿼리
+            service = params.get("service", "")
+            start = params.get("start", "")
+            end = params.get("end", "")
+            limit = params.get("limit", 20)
+            error_only = params.get("error_only", False)
+            
+            # 트레이스 쿼리 요청 구성
+            trace_request = TraceQueryRequest(
+                service_name=service,
+                error_traces=error_only,
+                time_period="1h"  # 기본값
+            )
+            
+            # 실제 트레이스 조회 함수 호출
+            logger.info(f"트레이스 쿼리: trace_id={None} service_name={service} error_traces={error_only} time_period='1h'")
+            
+            # 트레이스 API에 전달할 파라미터
+            api_params = {
+                "service_name": service,
+                "error_traces": error_only,
+                "limit": limit
+            }
+            
+            # 시간값이 있는 경우 추가 (ISO 형식으로 변환)
+            if start:
+                api_params["start_time"] = start
+            if end:
+                api_params["end_time"] = end
+            
+            # Tempo API 호출
+            result = await call_tempo_api_jsonrpc("query_tempo_traces", api_params)
+            
+            # 컨텍스트 업데이트: 서비스 추가
+            if service:
+                mcp_context.add_service(service)
+            
+            # 트레이스 ID 추출 및 컨텍스트 업데이트
+            traces = result.get("traces", [])
+            for trace in traces:
+                if "traceID" in trace:
+                    mcp_context.add_trace_id(trace["traceID"])
+            
+            return {"jsonrpc": "2.0", "result": traces, "id": id}
+        
+        elif method == "get_tempo_service_list" or method == "list_services":
+            # 서비스 목록 조회
+            services = await get_service_list()
+            return {"jsonrpc": "2.0", "result": services, "id": id}
+        
+        elif method == "get_trace":
+            # 특정 트레이스 ID 조회
+            trace_id = params.get("trace_id")
+            if not trace_id:
+                return {"jsonrpc": "2.0", "error": {"code": -32602, "message": "Trace ID is required"}, "id": id}
+            
+            # 트레이스 쿼리 요청 구성
+            trace_request = TraceQueryRequest(trace_id=trace_id)
+            
+            # API 호출 파라미터
+            api_params = {"trace_id": trace_id}
+            
+            # Tempo API 호출
+            result = await call_tempo_api_jsonrpc("get_trace", api_params)
+            
+            # 컨텍스트 업데이트
+            mcp_context.add_trace_id(trace_id)
+            
+            return {"jsonrpc": "2.0", "result": result.get("traces", []), "id": id}
+        
+        else:
+            # 지원하지 않는 메소드
+            return {"jsonrpc": "2.0", "error": {"code": -32601, "message": f"Method '{method}' not found"}, "id": id}
+    
+    except Exception as e:
+        logger.error(f"JSON-RPC 메소드 실행 오류: {str(e)}", exc_info=True)
+        return {"jsonrpc": "2.0", "error": {"code": -32603, "message": f"Internal error: {str(e)}"}, "id": id}
+
+# 서버 실행
+if __name__ == "__main__":
+    import uvicorn
+    PORT = int(os.getenv("TEMPO_MCP_PORT", 8004))
+    logger.info(f"Tempo MCP 서버 시작: 포트={PORT}")
+    uvicorn.run(app, host="0.0.0.0", port=PORT) 

--- a/mcp/tempo/requirements.txt
+++ b/mcp/tempo/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.104.1
+uvicorn==0.23.2
+httpx==0.25.1
+python-dotenv==1.0.0
+pydantic==2.4.2
+requests==2.31.0 


### PR DESCRIPTION
1. loki/tempo의 각 mcp-server(api) mcp-client(mcp) 를 생성
2. langgraph를 이용하여 생성도니 mpc-client, mcp-server를 활용하여 챗 기반으로 클라이언트의 의도를 읽어 정확한 응답 생성 로직 구축
3. docker compose 기반의 배포 파일 구성